### PR TITLE
feat: add Wan video generation tool

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -1340,6 +1340,7 @@ class SPAgentToolCallingScheduler(MultiTurnScheduler):
             ('Pi3Tool', 'pi3_tool'),
             ('VeoTool', 'video_generation_veo_tool'),
             ('SoraTool', 'video_generation_sora_tool'),
+            ('WanTool', 'video_generation_wan_tool'),
         ]
         
         for tool_class_name, tool_name in tool_classes:

--- a/spagent/external_experts/Wan/__init__.py
+++ b/spagent/external_experts/Wan/__init__.py
@@ -1,0 +1,4 @@
+from .wan_client import WanClient
+from .mock_wan_service import MockWanService
+
+__all__ = ["WanClient", "MockWanService"]

--- a/spagent/external_experts/Wan/mock_wan_service.py
+++ b/spagent/external_experts/Wan/mock_wan_service.py
@@ -1,0 +1,33 @@
+import os
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MockWanService:
+    """Mock Wan service for testing without API access."""
+
+    def generate_video(
+        self,
+        prompt: str,
+        image_path: str = None,
+        duration: int = 5,
+        aspect_ratio: str = "16:9",
+    ) -> dict:
+        logger.info(f"[Mock Wan] Generating video for prompt: {prompt[:80]}...")
+
+        if image_path and not image_path.startswith("http") and not os.path.exists(image_path):
+            return {"success": False, "error": f"Image not found: {image_path}"}
+
+        os.makedirs("outputs", exist_ok=True)
+        output_path = f"outputs/mock_wan_{int(time.time())}.mp4"
+        with open(output_path, "wb") as f:
+            f.write(b"\x00" * 1024)
+
+        return {
+            "success": True,
+            "output_path": output_path,
+            "file_size_bytes": 1024,
+            "mock": True,
+        }

--- a/spagent/external_experts/Wan/wan_client.py
+++ b/spagent/external_experts/Wan/wan_client.py
@@ -1,0 +1,195 @@
+import os
+import time
+import base64
+import logging
+import requests
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Supported sizes per aspect ratio
+SIZES = {
+    "16:9": "1280*720",
+    "9:16": "720*1280",
+    "1:1":  "960*960",
+}
+
+DASHSCOPE_BASE = "https://dashscope.aliyuncs.com/api/v1"
+
+
+class WanClient:
+    """Client for Alibaba Wan video generation via DashScope API.
+
+    Supports text-to-video (t2v) and image-to-video (i2v).
+    - t2v default model: wanx2.1-t2v-turbo
+    - i2v default model: wanx2.1-i2v-turbo  (auto-selected when image_path given)
+    """
+
+    def __init__(self, api_key: str = None, model: str = "wanx2.1-t2v-turbo"):
+        self.api_key = api_key or os.environ.get("DASHSCOPE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "DashScope API key is required. Set DASHSCOPE_API_KEY env variable "
+                "or pass api_key to WanClient."
+            )
+        self.model = model
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "X-DashScope-Async": "enable",
+        }
+
+    def generate_video(
+        self,
+        prompt: str,
+        image_path: str = None,
+        duration: int = 5,
+        aspect_ratio: str = "16:9",
+    ) -> dict:
+        """Generate a video from a text prompt, optionally conditioned on an image.
+
+        Args:
+            prompt: Text description of the video to generate.
+            image_path: Optional local path or public URL to a reference image
+                        for image-to-video generation.
+            duration: Video duration in seconds (3–10). Default 5.
+            aspect_ratio: "16:9", "9:16", or "1:1". Default "16:9".
+
+        Returns:
+            dict with keys: success, output_path, error.
+        """
+        try:
+            size = SIZES.get(aspect_ratio, SIZES["16:9"])
+            duration = max(3, min(10, duration))
+
+            # Auto-switch to i2v model when image provided
+            model = self.model
+            input_payload: dict = {"prompt": prompt}
+
+            if image_path:
+                model = self._to_i2v_model(model)
+                img_url = self._resolve_image(image_path)
+                if img_url is None:
+                    return {"success": False, "error": f"Image not found: {image_path}"}
+                input_payload["img_url"] = img_url
+
+            payload = {
+                "model": model,
+                "input": input_payload,
+                "parameters": {
+                    "size": size,
+                    "duration": duration,
+                },
+            }
+
+            url = f"{DASHSCOPE_BASE}/services/aigc/video-generation/video-synthesis"
+            logger.info(f"Sending video generation request to Wan (model={model})...")
+            resp = requests.post(url, headers=self.headers, json=payload, timeout=60)
+
+            if not resp.ok:
+                logger.error(f"Wan API error ({resp.status_code}): {resp.text}")
+                return {"success": False, "error": f"Wan API {resp.status_code}: {resp.text}"}
+
+            data = resp.json()
+            task_id = data.get("output", {}).get("task_id")
+            if not task_id:
+                return {"success": False, "error": f"No task_id in Wan response: {data}"}
+
+            logger.info(f"Wan task created: {task_id}")
+            return self._poll_task(task_id)
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Wan API request failed: {e}")
+            return {"success": False, "error": str(e)}
+        except Exception as e:
+            logger.error(f"Wan generation error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def _to_i2v_model(self, model: str) -> str:
+        """Swap t2v model to the corresponding i2v variant."""
+        if "t2v-turbo" in model:
+            return "wanx2.1-i2v-turbo"
+        if "t2v-plus" in model:
+            return "wanx2.1-i2v-plus"
+        # Already an i2v model or unknown — return as-is
+        return model
+
+    def _resolve_image(self, image_path: str):
+        """Return a public URL or base64 data-URL for the given image.
+
+        DashScope i2v accepts a URL in img_url.  For local files we encode
+        them as a data-URL (data:image/<ext>;base64,...).
+        """
+        # Already a URL
+        if image_path.startswith("http://") or image_path.startswith("https://"):
+            return image_path
+
+        # Local file — encode as data URL
+        if not os.path.exists(image_path):
+            return None
+
+        with open(image_path, "rb") as f:
+            image_bytes = base64.b64encode(f.read()).decode("utf-8")
+        ext = os.path.splitext(image_path)[1].lstrip(".").lower()
+        mime = f"image/{ext}" if ext in ("png", "jpeg", "jpg", "webp") else "image/jpeg"
+        return f"data:{mime};base64,{image_bytes}"
+
+    def _poll_task(self, task_id: str, timeout: int = 600, interval: int = 10) -> dict:
+        """Poll the DashScope task endpoint until completion."""
+        url = f"{DASHSCOPE_BASE}/tasks/{task_id}"
+        poll_headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        start = time.time()
+
+        while time.time() - start < timeout:
+            resp = requests.get(url, headers=poll_headers, timeout=30)
+            if not resp.ok:
+                logger.warning(f"Poll {resp.status_code}: {resp.text}")
+                time.sleep(interval)
+                continue
+
+            data = resp.json()
+            output = data.get("output", {})
+            status = output.get("task_status", "")
+
+            if status == "SUCCEEDED":
+                video_url = output.get("video_url")
+                if not video_url:
+                    return {"success": False, "error": f"No video_url in response: {output}"}
+                return self._download_video(video_url)
+
+            if status == "FAILED":
+                err = output.get("message", "Wan generation failed.")
+                return {"success": False, "error": err}
+
+            logger.info(
+                f"Wan generation: status={status} ({int(time.time() - start)}s elapsed)"
+            )
+            time.sleep(interval)
+
+        return {"success": False, "error": f"Wan generation timed out after {timeout}s"}
+
+    def _download_video(self, video_url: str) -> dict:
+        """Download the generated video and save locally."""
+        try:
+            os.makedirs("outputs", exist_ok=True)
+            output_path = f"outputs/wan_{int(time.time())}.mp4"
+
+            dl_resp = requests.get(video_url, timeout=120, stream=True)
+            dl_resp.raise_for_status()
+
+            with open(output_path, "wb") as f:
+                for chunk in dl_resp.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+            file_size = os.path.getsize(output_path)
+            logger.info(f"Wan video saved to: {output_path} ({file_size} bytes)")
+            return {
+                "success": True,
+                "output_path": output_path,
+                "file_size_bytes": file_size,
+            }
+        except Exception as e:
+            logger.error(f"Failed to download Wan video: {e}")
+            return {"success": False, "error": str(e)}

--- a/spagent/tools/__init__.py
+++ b/spagent/tools/__init__.py
@@ -17,10 +17,11 @@ from .vggt_tool import VGGTTool
 from .mapanything_tool import MapAnythingTool
 from .veo_tool import VeoTool
 from .sora_tool import SoraTool
+from .wan_tool import WanTool
 
 __all__ = [
     'DepthEstimationTool',
-    'SegmentationTool', 
+    'SegmentationTool',
     'ObjectDetectionTool',
     'SupervisionTool',
     'YOLOETool',
@@ -28,7 +29,8 @@ __all__ = [
     'Pi3Tool',
     'Pi3XTool',
     'VGGTTool',
-    'MapAnythingTool'
+    'MapAnythingTool',
     'VeoTool',
     'SoraTool',
+    'WanTool',
 ] 

--- a/spagent/tools/wan_tool.py
+++ b/spagent/tools/wan_tool.py
@@ -1,0 +1,125 @@
+"""
+Wan Video Generation Tool
+
+Wraps Alibaba Wan video generation (via DashScope) for the SPAgent system.
+Supports text-to-video and image-to-video generation.
+"""
+
+import sys
+import logging
+from pathlib import Path
+from typing import Dict, Any
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from core.tool import Tool
+
+logger = logging.getLogger(__name__)
+
+
+class WanTool(Tool):
+    """Tool for video generation using Alibaba Wan (DashScope)."""
+
+    def __init__(self, use_mock: bool = True, api_key: str = None, model: str = "wanx2.1-t2v-turbo"):
+        super().__init__(
+            name="video_generation_wan_tool",
+            description=(
+                "Generate a video from a text prompt (and optionally a reference image) "
+                "using Alibaba Wan. Returns the path to the generated .mp4 video file. "
+                "Use this when the task requires creating a video visualization, animation, "
+                "or video content from a description. Supports text-to-video and "
+                "image-to-video generation."
+            ),
+        )
+        self.use_mock = use_mock
+        self.api_key = api_key
+        self.model_name = model
+        self._client = None
+        self._init_client()
+
+    def _init_client(self):
+        if self.use_mock:
+            try:
+                from external_experts.Wan.mock_wan_service import MockWanService
+                self._client = MockWanService()
+                logger.info("Using mock Wan service")
+            except ImportError as e:
+                logger.error(f"Failed to import mock Wan service: {e}")
+                raise
+        else:
+            try:
+                from external_experts.Wan.wan_client import WanClient
+                self._client = WanClient(api_key=self.api_key, model=self.model_name)
+                logger.info("Using real Wan service (DashScope API)")
+            except ImportError as e:
+                logger.error(f"Failed to import Wan client: {e}")
+                raise
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Text description of the video to generate.",
+                },
+                "image_path": {
+                    "type": "string",
+                    "description": (
+                        "Optional path or URL to a reference image for image-to-video generation. "
+                        "When provided, the model generates a video conditioned on this image."
+                    ),
+                },
+                "duration": {
+                    "type": "integer",
+                    "description": "Video duration in seconds (3–10). Default is 5.",
+                    "default": 5,
+                },
+                "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio: '16:9', '9:16', or '1:1'. Default is '16:9'.",
+                    "enum": ["16:9", "9:16", "1:1"],
+                    "default": "16:9",
+                },
+            },
+            "required": ["prompt"],
+        }
+
+    def call(
+        self,
+        prompt: str,
+        image_path: str = None,
+        duration: int = 5,
+        aspect_ratio: str = "16:9",
+    ) -> Dict[str, Any]:
+        try:
+            logger.info(f"Generating video with Wan: {prompt[:80]}...")
+
+            if image_path and not image_path.startswith("http"):
+                from pathlib import Path as _Path
+                if not _Path(image_path).exists():
+                    return {"success": False, "error": f"Image file not found: {image_path}"}
+
+            result = self._client.generate_video(
+                prompt=prompt,
+                image_path=image_path,
+                duration=duration,
+                aspect_ratio=aspect_ratio,
+            )
+
+            if result and result.get("success"):
+                logger.info(f"Wan video generated: {result.get('output_path')}")
+                return {
+                    "success": True,
+                    "result": result,
+                    "output_path": result.get("output_path"),
+                }
+            else:
+                error_msg = result.get("error", "Unknown error") if result else "No result returned"
+                logger.error(f"Wan generation failed: {error_msg}")
+                return {"success": False, "error": f"Wan generation failed: {error_msg}"}
+
+        except Exception as e:
+            logger.error(f"Wan tool error: {e}")
+            return {"success": False, "error": str(e)}

--- a/test/wan/test_wan_tool.py
+++ b/test/wan/test_wan_tool.py
@@ -1,0 +1,76 @@
+"""
+Tests for WanTool — Alibaba Wan video generation.
+
+Usage:
+  # Mock test (no API key needed)
+  python test/wan/test_wan_tool.py --use_mock
+
+  # Real API test (requires DASHSCOPE_API_KEY)
+  python test/wan/test_wan_tool.py
+
+  # Image-to-video with real API
+  python test/wan/test_wan_tool.py --image_path path/to/image.png
+
+  # Custom duration / aspect ratio
+  python test/wan/test_wan_tool.py --use_mock --duration 8 --aspect_ratio 9:16
+"""
+
+import sys
+import argparse
+import logging
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "spagent"))
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test WanTool")
+    parser.add_argument("--use_mock", action="store_true", default=False,
+                        help="Use mock service instead of real API")
+    parser.add_argument("--image_path", type=str, default=None,
+                        help="Optional image path for image-to-video")
+    parser.add_argument("--duration", type=int, default=5,
+                        help="Video duration in seconds (3-10)")
+    parser.add_argument("--aspect_ratio", type=str, default="16:9",
+                        choices=["16:9", "9:16", "1:1"],
+                        help="Video aspect ratio")
+    parser.add_argument("--model", type=str, default="wanx2.1-t2v-turbo",
+                        help="Wan model name")
+    args = parser.parse_args()
+
+    from tools.wan_tool import WanTool
+
+    tool = WanTool(use_mock=args.use_mock, model=args.model)
+    logger.info(f"WanTool initialized (mock={args.use_mock})")
+
+    prompt = (
+        "A serene aerial shot of a mountain lake at sunrise, "
+        "mist rising from the water, golden light on snow-capped peaks."
+    )
+
+    logger.info(f"Prompt: {prompt}")
+    logger.info(f"Duration: {args.duration}s | Aspect ratio: {args.aspect_ratio}")
+    if args.image_path:
+        logger.info(f"Image: {args.image_path}")
+
+    result = tool.call(
+        prompt=prompt,
+        image_path=args.image_path,
+        duration=args.duration,
+        aspect_ratio=args.aspect_ratio,
+    )
+
+    if result["success"]:
+        logger.info(f"[PASS] Video generated: {result['output_path']}")
+        if result.get("result", {}).get("mock"):
+            logger.info("  (mock output)")
+    else:
+        logger.error(f"[FAIL] {result['error']}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
添加阿里 Wan (通义万象) 视频生成工具，支持 text-to-video 和 image-to-video。

通过 DashScope API 调用 wanx2.1 系列模型，提供 image 时自动切换到 i2v 模型。

## 新增文件

- `spagent/external_experts/Wan/` — WanClient + MockWanService
- `spagent/tools/wan_tool.py` — WanTool (name: `video_generation_wan_tool`)
- `test/wan/test_wan_tool.py` — 支持 `--use_mock` / `--image_path` / `--duration` / `--aspect_ratio` 参数

## 修改文件

- `spagent/tools/__init__.py` — 注册 WanTool
- `plugin/plugin.py` — 添加到 tool_classes

## 测试

- [x] Mock 测试通过
- [ ] DashScope API 真实调用（待 API key 配置后验证）