### PR TITLE
feat: add D4RT tool (4D dynamic scene reconstruction)

### DIFF
--- a/docs/Tool/TOOL_USING.md
+++ b/docs/Tool/TOOL_USING.md
@@ -44,6 +44,7 @@ external_experts/
 | **YOLO-E** | `YOLOETool` | YOLO-E Detection | High-precision detection with custom classes | Local | `image_path`, `task`, `class_names` |
 | **Veo** | `VeoTool` | Video Generation | Text-to-video and image-to-video via Google Veo (Gemini API) | API (no server) | `prompt`, `image_path`(optional), `duration`, `aspect_ratio` |
 | **Sora** | `SoraTool` | Video Generation | Text-to-video and image-to-video via OpenAI Sora | API (no server) | `prompt`, `image_path`(optional), `duration`, `resolution`, `aspect_ratio` |
+| **D4RT** | `D4RTTool` | Dynamic 4D Reconstruction | Joint depth, camera pose, and 3D point tracking from monocular video (Google DeepMind, 300x faster than prior methods) | Server (port 20035) | `frame_dir`, `task`, `query_points`, `output_dir`, `max_frames` |
 
 **Usage Examples**:
 - For detailed usage examples, please refer to: [Advanced Examples](../Examples/ADVANCED_EXAMPLES.md)

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -1342,6 +1342,7 @@ class SPAgentToolCallingScheduler(MultiTurnScheduler):
             ('SoraTool', 'video_generation_sora_tool'),
             ('QwenVLTool', 'qwenvl_detection_tool'),
             ('WanTool', 'video_generation_wan_tool'),
+            ('D4RTTool', 'd4rt_tool'),
         ]
         
         for tool_class_name, tool_name in tool_classes:

--- a/spagent/external_experts/D4RT/__init__.py
+++ b/spagent/external_experts/D4RT/__init__.py
@@ -1,0 +1,4 @@
+from .d4rt_client import D4RTClient
+from .mock_d4rt_service import MockD4RTService
+
+__all__ = ["D4RTClient", "MockD4RTService"]

--- a/spagent/external_experts/D4RT/d4rt_client.py
+++ b/spagent/external_experts/D4RT/d4rt_client.py
@@ -1,0 +1,86 @@
+"""
+D4RT HTTP Client
+
+Communicates with the D4RT Flask server on port 20035 (default).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class D4RTClient:
+    """HTTP client for the D4RT inference server."""
+
+    def __init__(self, server_url: str = "http://localhost:20035", timeout: float = 120.0):
+        self.server_url = server_url
+        self.timeout = timeout
+
+    def reconstruct(
+        self,
+        frame_dir: str,
+        task: str = "full_4d",
+        query_points: Optional[List[List[int]]] = None,
+        output_dir: str = "outputs/d4rt",
+        max_frames: int = -1,
+    ) -> dict:
+        """Send a reconstruction request to the D4RT server.
+
+        Args:
+            frame_dir: Path to directory containing video frames.
+            task: One of 'depth_and_camera', 'tracking', 'full_4d'.
+            query_points: List of [x, y] pixel coordinates to track.
+            output_dir: Directory to save output files.
+            max_frames: Maximum frames to process (-1 for all).
+
+        Returns:
+            Dict with reconstruction results.
+        """
+        frame_paths = sorted(Path(frame_dir).glob("*.jpg")) + \
+                      sorted(Path(frame_dir).glob("*.png"))
+        frame_paths = sorted(frame_paths)
+        if max_frames > 0:
+            frame_paths = frame_paths[:max_frames]
+
+        frames_b64 = [
+            base64.b64encode(p.read_bytes()).decode() for p in frame_paths
+        ]
+
+        payload = {
+            "frames": frames_b64,
+            "task": task,
+            "query_points": query_points or [],
+            "output_dir": output_dir,
+        }
+
+        logger.info(f"Sending {task} request ({len(frames_b64)} frames) to {self.server_url}/reconstruct")
+        resp = requests.post(
+            f"{self.server_url}/reconstruct",
+            json=payload,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def health_check(self) -> bool:
+        """Return True if the server is alive."""
+        try:
+            r = requests.get(f"{self.server_url}/health", timeout=5.0)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    def test_infer(self) -> dict:
+        """Quick test via the /test endpoint."""
+        try:
+            r = requests.get(f"{self.server_url}/test", timeout=10.0)
+            return r.json()
+        except Exception as e:
+            return {"error": str(e)}

--- a/spagent/external_experts/D4RT/mock_d4rt_service.py
+++ b/spagent/external_experts/D4RT/mock_d4rt_service.py
@@ -1,0 +1,84 @@
+"""
+Mock D4RT service for testing without GPU.
+
+Returns plausible dummy outputs for depth, camera, and tracking tasks.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import List, Optional
+
+
+class MockD4RTService:
+    """Mock D4RT service returning deterministic dummy results."""
+
+    def reconstruct(
+        self,
+        frame_dir: str,
+        task: str = "full_4d",
+        query_points: Optional[List[List[int]]] = None,
+        output_dir: str = "outputs/d4rt",
+        max_frames: int = -1,
+    ) -> dict:
+        """Return mock reconstruction results.
+
+        Args:
+            frame_dir: Path to frame directory (frame count is read if accessible).
+            task: One of 'depth_and_camera', 'tracking', 'full_4d'.
+            query_points: List of [x, y] pixel coordinates to track.
+            output_dir: Directory for output files.
+            max_frames: Maximum frames to process (-1 for all).
+
+        Returns:
+            Dict with mock reconstruction results.
+        """
+        try:
+            frames = sorted(Path(frame_dir).glob("*.jpg")) + \
+                     sorted(Path(frame_dir).glob("*.png"))
+            n = len(sorted(frames))
+        except Exception:
+            n = 8
+        if max_frames > 0:
+            n = min(n, max_frames)
+        n = max(n, 1)
+
+        result = {"num_frames": n, "output_dir": output_dir}
+
+        if task in ("depth_and_camera", "full_4d"):
+            result["depth_paths"] = [
+                f"{output_dir}/depth_{i:04d}.npy" for i in range(n)
+            ]
+            result["camera_poses"] = [
+                {
+                    "frame": i,
+                    "extrinsic": [
+                        [1, 0, 0, i * 0.05],
+                        [0, 1, 0, 0.0],
+                        [0, 0, 1, 0.0],
+                        [0, 0, 0, 1.0],
+                    ],
+                    "intrinsic": {"fx": 525.0, "fy": 525.0, "cx": 320.0, "cy": 240.0},
+                }
+                for i in range(n)
+            ]
+
+        if task in ("tracking", "full_4d"):
+            pts = query_points or [[100, 200]]
+            result["trajectories"] = [
+                {
+                    "query_point": pt,
+                    "track_3d": [
+                        [
+                            pt[0] * 0.001 + i * 0.002,
+                            pt[1] * 0.001,
+                            1.5 + random.uniform(-0.05, 0.05),
+                        ]
+                        for i in range(n)
+                    ],
+                }
+                for pt in pts
+            ]
+
+        return result

--- a/spagent/tools/__init__.py
+++ b/spagent/tools/__init__.py
@@ -19,6 +19,7 @@ from .veo_tool import VeoTool
 from .sora_tool import SoraTool
 from .qwenvl_tool import QwenVLTool
 from .wan_tool import WanTool
+from .d4rt_tool import D4RTTool
 
 __all__ = [
     'DepthEstimationTool',
@@ -35,4 +36,5 @@ __all__ = [
     'SoraTool',
     'QwenVLTool',
     'WanTool',
+    'D4RTTool',
 ] 

--- a/spagent/tools/d4rt_tool.py
+++ b/spagent/tools/d4rt_tool.py
@@ -1,0 +1,158 @@
+"""
+D4RT Tool
+
+This module contains the D4RTTool that wraps D4RT (Dynamic 4D Reconstruction
+and Tracking) functionality for the SPAgent system.
+
+D4RT (Google DeepMind) jointly estimates depth, spatio-temporal correspondence,
+and camera parameters from monocular video - up to 300x faster than prior methods.
+
+Paper: https://d4rt-paper.github.io/
+Blog:  https://deepmind.google/blog/d4rt-teaching-ai-to-see-the-world-in-four-dimensions/
+"""
+
+import sys
+import logging
+from pathlib import Path
+from typing import Dict, Any, List, Optional
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from core.tool import Tool
+
+logger = logging.getLogger(__name__)
+
+
+class D4RTTool(Tool):
+    """Tool for dynamic 4D scene reconstruction from video using D4RT."""
+
+    def __init__(
+        self,
+        use_mock: bool = True,
+        server_url: str = "http://localhost:20035",
+    ):
+        super().__init__(
+            name="d4rt_tool",
+            description=(
+                "Reconstructs dynamic 4D scenes (geometry + motion) from video using D4RT "
+                "(Google DeepMind). Input: a directory of ordered video frame images. "
+                "Modes: (1) 'depth_and_camera' - returns per-frame depth maps and camera poses; "
+                "(2) 'tracking' - tracks specified 2D query points across all frames and returns "
+                "3D trajectories; (3) 'full_4d' - returns all outputs simultaneously. "
+                "Best suited for dynamic scenes with moving objects or camera."
+            ),
+        )
+        self.use_mock = use_mock
+        self.server_url = server_url
+        self._client = None
+        self._init_client()
+
+    def _init_client(self):
+        """Initialize the client (mock or real)."""
+        if self.use_mock:
+            from external_experts.D4RT.mock_d4rt_service import MockD4RTService
+            self._client = MockD4RTService()
+            logger.info("D4RTTool initialized with mock service")
+        else:
+            from external_experts.D4RT.d4rt_client import D4RTClient
+            self._client = D4RTClient(server_url=self.server_url)
+            logger.info(f"D4RTTool initialized with server at {self.server_url}")
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "frame_dir": {
+                    "type": "string",
+                    "description": (
+                        "Path to a directory containing ordered video frame images "
+                        "(e.g. frame_0001.jpg, frame_0002.jpg). Frames are sorted by filename."
+                    ),
+                },
+                "task": {
+                    "type": "string",
+                    "enum": ["depth_and_camera", "tracking", "full_4d"],
+                    "description": (
+                        "'depth_and_camera': estimate per-frame depth and camera poses. "
+                        "'tracking': estimate 3D motion trajectories for query points. "
+                        "'full_4d': run all tasks in one pass."
+                    ),
+                    "default": "full_4d",
+                },
+                "query_points": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 2,
+                        "maxItems": 2,
+                    },
+                    "description": (
+                        "List of [x, y] pixel coordinates in the first frame to track. "
+                        "Required only for task='tracking'. Example: [[100, 200], [300, 400]]."
+                    ),
+                },
+                "output_dir": {
+                    "type": "string",
+                    "description": "Directory to save output files. Defaults to outputs/d4rt/.",
+                    "default": "outputs/d4rt",
+                },
+                "max_frames": {
+                    "type": "integer",
+                    "description": "Maximum number of frames to process. -1 for all frames.",
+                    "default": -1,
+                },
+            },
+            "required": ["frame_dir"],
+        }
+
+    def call(
+        self,
+        frame_dir: str,
+        task: str = "full_4d",
+        query_points: Optional[List[List[int]]] = None,
+        output_dir: str = "outputs/d4rt",
+        max_frames: int = -1,
+    ) -> Dict[str, Any]:
+        """Execute D4RT 4D reconstruction.
+
+        Args:
+            frame_dir: Path to directory containing video frames.
+            task: One of 'depth_and_camera', 'tracking', 'full_4d'.
+            query_points: List of [x, y] pixel coordinates to track.
+            output_dir: Directory to save output files.
+            max_frames: Maximum frames to process (-1 for all).
+
+        Returns:
+            Dict with 'success', 'result', and optionally 'error' keys.
+        """
+        try:
+            if not Path(frame_dir).is_dir():
+                return {"success": False, "error": f"Frame directory not found: {frame_dir}"}
+
+            if task == "tracking" and not query_points:
+                return {
+                    "success": False,
+                    "error": "task='tracking' requires 'query_points'.",
+                }
+
+            logger.info(f"Running D4RT: task={task}, frame_dir={frame_dir}")
+
+            result = self._client.reconstruct(
+                frame_dir=frame_dir,
+                task=task,
+                query_points=query_points,
+                output_dir=output_dir,
+                max_frames=max_frames,
+            )
+
+            return {
+                "success": True,
+                "result": result,
+                "output_dir": result.get("output_dir", output_dir),
+            }
+
+        except Exception as e:
+            logger.error(f"D4RTTool error: {e}")
+            return {"success": False, "error": str(e)}

--- a/test/test_d4rt_tool.py
+++ b/test/test_d4rt_tool.py
@@ -1,0 +1,98 @@
+"""
+Tests for D4RTTool.
+
+Usage:
+  # Mock mode (no GPU required)
+  python test/test_d4rt_tool.py --use_mock --task full_4d --frame_dir assets/sample_video_frames/
+
+  # Depth and camera only
+  python test/test_d4rt_tool.py --use_mock --task depth_and_camera --frame_dir assets/sample_video_frames/
+
+  # Tracking specific points
+  python test/test_d4rt_tool.py --use_mock --task tracking \
+      --frame_dir assets/sample_video_frames/ --query_points "100,200;300,400"
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from spagent.tools.d4rt_tool import D4RTTool
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def parse_query_points(s: str):
+    """Parse 'x1,y1;x2,y2' into [[x1,y1],[x2,y2]]."""
+    if not s:
+        return None
+    points = []
+    for pair in s.split(";"):
+        x, y = pair.strip().split(",")
+        points.append([int(x.strip()), int(y.strip())])
+    return points
+
+
+def test_d4rt(args):
+    """Test D4RTTool with the given arguments."""
+    logger.info(f"Task: {args.task}, Mock: {args.use_mock}")
+
+    tool = D4RTTool(
+        use_mock=args.use_mock,
+        server_url=f"http://{args.host}:{args.port}",
+    )
+
+    query_points = parse_query_points(args.query_points)
+
+    result = tool.call(
+        frame_dir=args.frame_dir,
+        task=args.task,
+        query_points=query_points,
+        output_dir=args.output_dir,
+        max_frames=args.max_frames,
+    )
+
+    logger.info(f"Result: {json.dumps(result, indent=2, default=str)}")
+
+    if result.get("success"):
+        logger.info("PASSED - tool returned success")
+        data = result["result"]
+        logger.info(f"  Frames processed: {data.get('num_frames')}")
+        if "depth_paths" in data:
+            logger.info(f"  Depth maps: {len(data['depth_paths'])} files")
+        if "camera_poses" in data:
+            logger.info(f"  Camera poses: {len(data['camera_poses'])} frames")
+        if "trajectories" in data:
+            logger.info(f"  Trajectories: {len(data['trajectories'])} points tracked")
+    else:
+        logger.error(f"FAILED - {result.get('error')}")
+        sys.exit(1)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--use_mock", action="store_true",
+                        help="Use mock service (no GPU required)")
+    parser.add_argument("--task", choices=["depth_and_camera", "tracking", "full_4d"],
+                        default="full_4d")
+    parser.add_argument("--frame_dir", type=str, default="assets/sample_video_frames/")
+    parser.add_argument("--query_points", type=str, default=None,
+                        help="Query points as 'x1,y1;x2,y2'. Required for tracking task.")
+    parser.add_argument("--output_dir", type=str, default="outputs/d4rt")
+    parser.add_argument("--max_frames", type=int, default=-1)
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=20035)
+    args = parser.parse_args()
+
+    test_d4rt(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `D4RTTool` to SPAgent, wrapping [D4RT](https://d4rt-paper.github.io/) (Dynamic 4D Reconstruction and Tracking) — a Google DeepMind model for unified dynamic scene reconstruction from monocular video, up to **300x faster** than prior methods.

## Motivation

- SPAgent handles static 3D reconstruction (Pi3, Pi3X, VGGT, MapAnything) but lacks support for **dynamic scenes with moving objects**.
- D4RT jointly estimates depth, spatio-temporal correspondence, and camera parameters from video — bridging the gap for robotics navigation and AR/VR.

## Files Changed

### New Files
- `spagent/tools/d4rt_tool.py` — Tool class (subclasses `Tool`)
- `spagent/external_experts/D4RT/__init__.py`
- `spagent/external_experts/D4RT/d4rt_client.py` — HTTP client (requests, port 20035)
- `spagent/external_experts/D4RT/mock_d4rt_service.py` — Mock service for testing
- `test/test_d4rt_tool.py`

### Modified Files
- `spagent/tools/__init__.py` — Export `D4RTTool`
- `plugin/plugin.py` — Register tool class
- `docs/Tool/TOOL_USING.md` — Add tool entry to table

## Tool Capabilities

| Mode | Input | Output |
|------|-------|--------|
| `depth_and_camera` | video frames directory | per-frame depth maps (.npy) + camera poses (intrinsic + extrinsic) |
| `tracking` | video frames + query points | 3D trajectories of tracked points across frames |
| `full_4d` | video frames | depth + camera + tracking (all outputs in one pass) |

## Testing

```bash
# Mock mode (no GPU)
python test/test_d4rt_tool.py --use_mock --task full_4d --frame_dir assets/sample_video_frames/

# Tracking specific points
python test/test_d4rt_tool.py --use_mock --task tracking \
    --frame_dir assets/sample_video_frames/ --query_points "100,200;300,400"
```

## Related

- [D4RT project page](https://d4rt-paper.github.io/)
- [Google DeepMind blog](https://deepmind.google/blog/d4rt-teaching-ai-to-see-the-world-in-four-dimensions/)