### PR TITLE
feat: add SoFar tool (language-grounded manipulation pose)

### DIFF
--- a/docs/Tool/TOOL_USING.md
+++ b/docs/Tool/TOOL_USING.md
@@ -44,6 +44,7 @@ external_experts/
 | **YOLO-E** | `YOLOETool` | YOLO-E Detection | High-precision detection with custom classes | Local | `image_path`, `task`, `class_names` |
 | **Veo** | `VeoTool` | Video Generation | Text-to-video and image-to-video via Google Veo (Gemini API) | API (no server) | `prompt`, `image_path`(optional), `duration`, `aspect_ratio` |
 | **Sora** | `SoraTool` | Video Generation | Text-to-video and image-to-video via OpenAI Sora | API (no server) | `prompt`, `image_path`(optional), `duration`, `resolution`, `aspect_ratio` |
+| **SoFar** | `SoFarTool` | Robot Manipulation Pose | Language-grounded 6-DoF pose estimation and grasp affordance for robot manipulation (NeurIPS 2025 Spotlight) | Server (port 20036) | `image_path`, `instruction`, `camera_intrinsics` |
 
 **Usage Examples**:
 - For detailed usage examples, please refer to: [Advanced Examples](../Examples/ADVANCED_EXAMPLES.md)

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -1342,6 +1342,7 @@ class SPAgentToolCallingScheduler(MultiTurnScheduler):
             ('SoraTool', 'video_generation_sora_tool'),
             ('QwenVLTool', 'qwenvl_detection_tool'),
             ('WanTool', 'video_generation_wan_tool'),
+            ('SoFarTool', 'sofar_tool'),
         ]
         
         for tool_class_name, tool_name in tool_classes:

--- a/spagent/external_experts/SoFar/__init__.py
+++ b/spagent/external_experts/SoFar/__init__.py
@@ -1,0 +1,4 @@
+from .sofar_client import SoFarClient
+from .mock_sofar_service import MockSoFarService
+
+__all__ = ["SoFarClient", "MockSoFarService"]

--- a/spagent/external_experts/SoFar/mock_sofar_service.py
+++ b/spagent/external_experts/SoFar/mock_sofar_service.py
@@ -1,0 +1,60 @@
+"""
+Mock SoFar service for testing without GPU.
+
+Returns plausible dummy outputs for 6-DoF pose estimation.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+
+class MockSoFarService:
+    """Deterministic (seeded by instruction) mock for offline testing."""
+
+    def infer(
+        self,
+        image_path: str,
+        instruction: str,
+        camera_intrinsics: Optional[dict] = None,
+    ) -> dict:
+        """Return mock pose estimation results.
+
+        Args:
+            image_path: Path to the scene image (not read in mock mode).
+            instruction: Manipulation instruction (used as RNG seed).
+            camera_intrinsics: Optional camera intrinsics (ignored in mock).
+
+        Returns:
+            Dict with mock pose estimation results.
+        """
+        rng = random.Random(hash(instruction) & 0xFFFFFFFF)
+        z = rng.uniform(0.3, 1.2)
+        return {
+            "bbox": [
+                rng.randint(100, 200), rng.randint(100, 200),
+                rng.randint(300, 500), rng.randint(300, 500),
+            ],
+            "position": {
+                "x": round(rng.uniform(-0.3, 0.3), 4),
+                "y": round(rng.uniform(-0.2, 0.2), 4),
+                "z": round(z, 4),
+            },
+            "quaternion": {
+                "w": round(rng.uniform(0.7, 1.0), 4),
+                "x": round(rng.uniform(-0.3, 0.3), 4),
+                "y": round(rng.uniform(-0.3, 0.3), 4),
+                "z": round(rng.uniform(-0.3, 0.3), 4),
+            },
+            "approach_vector": [
+                round(rng.uniform(-0.1, 0.1), 3),
+                round(rng.uniform(-0.1, 0.1), 3),
+                -1.0,
+            ],
+            "spatial_description": (
+                f"Target object detected at approximately {z:.2f}m from camera. "
+                f"Orientation suggests top-down approach is optimal."
+            ),
+            "confidence": round(rng.uniform(0.72, 0.96), 3),
+        }

--- a/spagent/external_experts/SoFar/sofar_client.py
+++ b/spagent/external_experts/SoFar/sofar_client.py
@@ -1,0 +1,71 @@
+"""
+SoFar HTTP Client
+
+Communicates with the SoFar Flask server on port 20036 (default).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class SoFarClient:
+    """HTTP client for the SoFar inference server."""
+
+    def __init__(self, server_url: str = "http://localhost:20036", timeout: float = 60.0):
+        self.server_url = server_url
+        self.timeout = timeout
+
+    def infer(
+        self,
+        image_path: str,
+        instruction: str,
+        camera_intrinsics: Optional[dict] = None,
+    ) -> dict:
+        """Send an inference request to the SoFar server.
+
+        Args:
+            image_path: Path to the RGB scene image.
+            instruction: Natural language manipulation instruction.
+            camera_intrinsics: Optional dict with fx, fy, cx, cy.
+
+        Returns:
+            Dict with pose estimation results.
+        """
+        payload = {
+            "image": base64.b64encode(Path(image_path).read_bytes()).decode(),
+            "instruction": instruction,
+            "camera_intrinsics": camera_intrinsics or {},
+        }
+
+        logger.info(f"Sending infer request to {self.server_url}/infer")
+        resp = requests.post(
+            f"{self.server_url}/infer",
+            json=payload,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def health_check(self) -> bool:
+        """Return True if the server is alive."""
+        try:
+            r = requests.get(f"{self.server_url}/health", timeout=5.0)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    def test_infer(self) -> dict:
+        """Quick test via the /test endpoint."""
+        try:
+            r = requests.get(f"{self.server_url}/test", timeout=10.0)
+            return r.json()
+        except Exception as e:
+            return {"error": str(e)}

--- a/spagent/tools/__init__.py
+++ b/spagent/tools/__init__.py
@@ -19,6 +19,7 @@ from .veo_tool import VeoTool
 from .sora_tool import SoraTool
 from .qwenvl_tool import QwenVLTool
 from .wan_tool import WanTool
+from .sofar_tool import SoFarTool
 
 __all__ = [
     'DepthEstimationTool',
@@ -35,4 +36,5 @@ __all__ = [
     'SoraTool',
     'QwenVLTool',
     'WanTool',
+    'SoFarTool',
 ] 

--- a/spagent/tools/sofar_tool.py
+++ b/spagent/tools/sofar_tool.py
@@ -1,0 +1,127 @@
+"""
+SoFar Tool
+
+This module contains the SoFarTool that wraps SoFar (Spatial Orientation
+from Affordance Reasoning) functionality for the SPAgent system.
+
+SoFar (NeurIPS 2025 Spotlight) bridges spatial reasoning and robot manipulation
+through language-grounded orientation understanding.
+
+Paper: https://github.com/qizekun/SoFar
+"""
+
+import sys
+import logging
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from core.tool import Tool
+
+logger = logging.getLogger(__name__)
+
+
+class SoFarTool(Tool):
+    """Tool for language-grounded 6-DoF pose estimation using SoFar."""
+
+    def __init__(
+        self,
+        use_mock: bool = True,
+        server_url: str = "http://localhost:20036",
+    ):
+        super().__init__(
+            name="sofar_tool",
+            description=(
+                "Estimates 6-DoF object pose and grasp affordance for robot manipulation "
+                "using SoFar (NeurIPS 2025 Spotlight). Input: an RGB image and a natural "
+                "language instruction (e.g. 'pick up the mug by the handle'). "
+                "Output: bounding box of the target object, its 6-DoF pose relative to the "
+                "camera, recommended approach vector for gripper, and a human-readable "
+                "spatial description. Ideal for embodied AI and robotic manipulation tasks."
+            ),
+        )
+        self.use_mock = use_mock
+        self.server_url = server_url
+        self._client = None
+        self._init_client()
+
+    def _init_client(self):
+        """Initialize the client (mock or real)."""
+        if self.use_mock:
+            from external_experts.SoFar.mock_sofar_service import MockSoFarService
+            self._client = MockSoFarService()
+            logger.info("SoFarTool initialized with mock service")
+        else:
+            from external_experts.SoFar.sofar_client import SoFarClient
+            self._client = SoFarClient(server_url=self.server_url)
+            logger.info(f"SoFarTool initialized with server at {self.server_url}")
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "image_path": {
+                    "type": "string",
+                    "description": "Absolute path to the RGB scene image.",
+                },
+                "instruction": {
+                    "type": "string",
+                    "description": (
+                        "Natural language manipulation instruction specifying the target "
+                        "object and desired action. "
+                        "Examples: 'pick up the blue mug by the handle', "
+                        "'grasp the bottle from the top', 'open the drawer on the left'."
+                    ),
+                },
+                "camera_intrinsics": {
+                    "type": "object",
+                    "description": (
+                        "Optional camera intrinsics for metric-scale output. "
+                        "Keys: fx, fy, cx, cy (pixels). If omitted, relative pose is returned."
+                    ),
+                    "properties": {
+                        "fx": {"type": "number"},
+                        "fy": {"type": "number"},
+                        "cx": {"type": "number"},
+                        "cy": {"type": "number"},
+                    },
+                },
+            },
+            "required": ["image_path", "instruction"],
+        }
+
+    def call(
+        self,
+        image_path: str,
+        instruction: str,
+        camera_intrinsics: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Any]:
+        """Execute SoFar pose estimation.
+
+        Args:
+            image_path: Path to the RGB scene image.
+            instruction: Natural language manipulation instruction.
+            camera_intrinsics: Optional dict with fx, fy, cx, cy.
+
+        Returns:
+            Dict with 'success', 'result', and optionally 'error' keys.
+        """
+        try:
+            if not Path(image_path).exists():
+                return {"success": False, "error": f"Image not found: {image_path}"}
+
+            logger.info(f"Running SoFar: instruction='{instruction}'")
+
+            result = self._client.infer(
+                image_path=image_path,
+                instruction=instruction,
+                camera_intrinsics=camera_intrinsics,
+            )
+
+            return {"success": True, "result": result}
+
+        except Exception as e:
+            logger.error(f"SoFarTool error: {e}")
+            return {"success": False, "error": str(e)}

--- a/test/test_sofar_tool.py
+++ b/test/test_sofar_tool.py
@@ -1,0 +1,76 @@
+"""
+Tests for SoFarTool.
+
+Usage:
+  # Mock mode (no GPU required)
+  python test/test_sofar_tool.py --use_mock \
+      --image_path assets/table_scene.jpg \
+      --instruction "pick up the blue bottle"
+
+  # Real server (start sofar_server.py first)
+  python test/test_sofar_tool.py \
+      --image_path assets/table_scene.jpg \
+      --instruction "grasp the mug by its handle"
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from spagent.tools.sofar_tool import SoFarTool
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def test_sofar(args):
+    """Test SoFarTool with the given arguments."""
+    logger.info(f"Instruction: '{args.instruction}', Mock: {args.use_mock}")
+
+    tool = SoFarTool(
+        use_mock=args.use_mock,
+        server_url=f"http://{args.host}:{args.port}",
+    )
+
+    result = tool.call(
+        image_path=args.image_path,
+        instruction=args.instruction,
+    )
+
+    logger.info(f"Result: {json.dumps(result, indent=2, default=str)}")
+
+    if result.get("success"):
+        logger.info("PASSED - tool returned success")
+        data = result["result"]
+        logger.info(f"  Bbox: {data.get('bbox')}")
+        logger.info(f"  Position: {data.get('position')}")
+        logger.info(f"  Quaternion: {data.get('quaternion')}")
+        logger.info(f"  Approach vector: {data.get('approach_vector')}")
+        logger.info(f"  Spatial desc: {data.get('spatial_description')}")
+        logger.info(f"  Confidence: {data.get('confidence')}")
+    else:
+        logger.error(f"FAILED - {result.get('error')}")
+        sys.exit(1)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--use_mock", action="store_true",
+                        help="Use mock service (no GPU required)")
+    parser.add_argument("--image_path", type=str, default="assets/table_scene.jpg")
+    parser.add_argument("--instruction", type=str, default="pick up the blue bottle")
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=20036)
+    args = parser.parse_args()
+
+    test_sofar(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `SoFarTool` to SPAgent, wrapping [SoFar](https://github.com/qizekun/SoFar) — a **NeurIPS 2025 Spotlight** model that bridges spatial reasoning and robot manipulation through language-grounded orientation understanding.

## Motivation

- SPAgent has strong 3D reconstruction but no direct bridge to **robot manipulation**.
- SoFar closes this gap: given "pick up the mug by the handle", it outputs the exact 6-DoF pose needed by a robot controller.
- Complements OrientAnythingV2 (general orientation) with manipulation-specific semantics.

## Files Changed

### New Files
- `spagent/tools/sofar_tool.py` — Tool class (subclasses `Tool`)
- `spagent/external_experts/SoFar/__init__.py`
- `spagent/external_experts/SoFar/sofar_client.py` — HTTP client (requests, port 20036)
- `spagent/external_experts/SoFar/mock_sofar_service.py` — Mock service for testing
- `test/test_sofar_tool.py`

### Modified Files
- `spagent/tools/__init__.py` — Export `SoFarTool`
- `plugin/plugin.py` — Register tool class
- `docs/Tool/TOOL_USING.md` — Add tool entry to table

## Tool Capabilities

| Input | Output |
|-------|--------|
| RGB image + natural language instruction | Target object bounding box |
| (e.g. "pick up the blue mug by the handle") | 6-DoF pose: position (x,y,z metres) + orientation (quaternion) |
| Optional: camera intrinsics for metric scale | Approach vector for robot gripper |
| | Human-readable spatial description + confidence |

## Testing

```bash
# Mock mode (no GPU)
python test/test_sofar_tool.py --use_mock \
    --image_path assets/table_scene.jpg \
    --instruction "pick up the blue bottle"

# Real server
python test/test_sofar_tool.py \
    --image_path assets/table_scene.jpg \
    --instruction "grasp the mug by its handle"
```

## Related

- [SoFar (NeurIPS 2025 Spotlight)](https://github.com/qizekun/SoFar)
- Pairs well with `feat/orient-anything-v2` for comprehensive spatial orientation support