### PR TITLE
feat: add Ctrl-World tool integration for SPAgent

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -1342,6 +1342,7 @@ class SPAgentToolCallingScheduler(MultiTurnScheduler):
             ('SoraTool', 'video_generation_sora_tool'),
             ('QwenVLTool', 'qwenvl_detection_tool'),
             ('WanTool', 'video_generation_wan_tool'),
+            ('CtrlWorldTool', 'world_model_ctrl_world_tool'),
         ]
         
         for tool_class_name, tool_name in tool_classes:

--- a/spagent/external_experts/CtrlWorld/__init__.py
+++ b/spagent/external_experts/CtrlWorld/__init__.py
@@ -1,0 +1,4 @@
+from .ctrl_world_client import CtrlWorldClient
+from .mock_ctrl_world_service import MockCtrlWorldService
+
+__all__ = ["CtrlWorldClient", "MockCtrlWorldService"]

--- a/spagent/external_experts/CtrlWorld/ctrl_world_client.py
+++ b/spagent/external_experts/CtrlWorld/ctrl_world_client.py
@@ -1,0 +1,117 @@
+import base64
+import logging
+import os
+import time
+from typing import Any, Dict, List
+
+import requests
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class CtrlWorldClient:
+    """HTTP client for Ctrl-World local server."""
+
+    def __init__(self, server_url: str = "http://localhost:20040", timeout: int = 300):
+        self.server_url = server_url.rstrip("/")
+        self.timeout = timeout
+
+    def health_check(self) -> Dict[str, Any]:
+        try:
+            resp = requests.get(f"{self.server_url}/health", timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            logger.error(f"Ctrl-World health check failed: {e}")
+            return {"success": False, "error": str(e)}
+
+    def generate_trajectory(
+        self,
+        image_path: str,
+        actions: List[List[float]],
+        instruction: str = "",
+        task_type: str = "pickplace",
+    ) -> Dict[str, Any]:
+        try:
+            if image_path.startswith("http://") or image_path.startswith("https://"):
+                return {
+                    "success": False,
+                    "error": "Remote image URLs are not supported by Ctrl-World local server.",
+                }
+
+            if not os.path.exists(image_path):
+                return {"success": False, "error": f"Image not found: {image_path}"}
+
+            image_data = self._encode_image(image_path)
+            payload = {
+                "image": image_data,
+                "actions": actions,
+                "instruction": instruction,
+                "task_type": task_type,
+            }
+
+            logger.info(
+                f"Sending Ctrl-World generate request: task={task_type}, "
+                f"actions={len(actions)}"
+            )
+            resp = requests.post(
+                f"{self.server_url}/generate",
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=self.timeout,
+            )
+
+            if not resp.ok:
+                logger.error(f"Ctrl-World server error ({resp.status_code}): {resp.text}")
+                return {
+                    "success": False,
+                    "error": f"Ctrl-World server {resp.status_code}: {resp.text}",
+                }
+
+            result = resp.json()
+            if not result.get("success"):
+                return {"success": False, "error": result.get("error", "Unknown error")}
+
+            output_path = result.get("output_path")
+            if output_path and os.path.exists(output_path):
+                file_size = os.path.getsize(output_path)
+                return {
+                    "success": True,
+                    "output_path": output_path,
+                    "file_size_bytes": file_size,
+                    "result": result,
+                }
+
+            video_b64 = result.get("video_base64")
+            if not video_b64:
+                return {"success": False, "error": "No output_path or video_base64 returned by server."}
+
+            os.makedirs("outputs", exist_ok=True)
+            output_path = f"outputs/ctrl_world_{int(time.time())}.mp4"
+            with open(output_path, "wb") as f:
+                f.write(base64.b64decode(video_b64))
+
+            return {
+                "success": True,
+                "output_path": output_path,
+                "file_size_bytes": os.path.getsize(output_path),
+                "result": result,
+            }
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Ctrl-World request failed: {e}")
+            return {"success": False, "error": str(e)}
+        except Exception as e:
+            logger.error(f"Ctrl-World client error: {e}")
+            return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def _encode_image(image_path: str) -> Dict[str, str]:
+        with open(image_path, "rb") as f:
+            image_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+        ext = os.path.splitext(image_path)[1].lstrip(".").lower()
+        if ext == "jpg":
+            ext = "jpeg"
+        mime = f"image/{ext}" if ext in ("png", "jpeg", "webp") else "image/jpeg"
+        return {"mime_type": mime, "data_base64": image_b64}

--- a/spagent/external_experts/CtrlWorld/mock_ctrl_world_service.py
+++ b/spagent/external_experts/CtrlWorld/mock_ctrl_world_service.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class MockCtrlWorldService:
+    """Mock Ctrl-World service for local testing."""
+
+    def generate_trajectory(
+        self,
+        image_path: str,
+        actions: list,
+        instruction: str = "",
+        task_type: str = "pickplace",
+    ) -> dict:
+        logger.info(
+            f"[Mock Ctrl-World] task={task_type}, "
+            f"actions={len(actions) if actions else 0}"
+        )
+
+        if image_path and not image_path.startswith("http") and not os.path.exists(image_path):
+            return {"success": False, "error": f"Image not found: {image_path}"}
+
+        if not isinstance(actions, list) or not actions:
+            return {"success": False, "error": "actions must be a non-empty list"}
+
+        os.makedirs("outputs", exist_ok=True)
+        output_path = f"outputs/mock_ctrl_world_{int(time.time())}.mp4"
+
+        with open(output_path, "wb") as f:
+            f.write(b"\x00" * 1024)
+
+        return {
+            "success": True,
+            "output_path": output_path,
+            "file_size_bytes": 1024,
+            "mock": True,
+            "task_type": task_type,
+            "instruction": instruction,
+        }

--- a/spagent/tools/__init__.py
+++ b/spagent/tools/__init__.py
@@ -19,6 +19,7 @@ from .veo_tool import VeoTool
 from .sora_tool import SoraTool
 from .qwenvl_tool import QwenVLTool
 from .wan_tool import WanTool
+from .ctrl_world_tool import CtrlWorldTool
 
 __all__ = [
     'DepthEstimationTool',
@@ -35,4 +36,5 @@ __all__ = [
     'SoraTool',
     'QwenVLTool',
     'WanTool',
+    'CtrlWorldTool',
 ] 

--- a/spagent/tools/ctrl_world_tool.py
+++ b/spagent/tools/ctrl_world_tool.py
@@ -1,0 +1,170 @@
+"""
+Ctrl-World Tool
+
+Wraps Ctrl-World trajectory/video generation for the SPAgent system.
+Supports generating rollout videos from an initial image and action sequence.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from core.tool import Tool
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_TASK_TYPES = [
+    "replay",
+    "keyboard",
+    "pickplace",
+    "towel_fold",
+    "wipe_table",
+    "tissue",
+    "close_laptop",
+    "stack",
+    "drawer",
+]
+
+
+class CtrlWorldTool(Tool):
+    """Tool for controllable world-model rollout generation."""
+
+    def __init__(self, use_mock: bool = True, server_url: str = "http://localhost:20040"):
+        super().__init__(
+            name="world_model_ctrl_world_tool",
+            description=(
+                "Generate a rollout video trajectory using Ctrl-World from an initial image, "
+                "an action sequence, and optional task instruction. Use this when the task "
+                "needs controllable world-model simulation for robot manipulation."
+            ),
+        )
+        self.use_mock = use_mock
+        self.server_url = server_url
+        self._client = None
+        self._init_client()
+
+    def _init_client(self):
+        if self.use_mock:
+            try:
+                from external_experts.CtrlWorld.mock_ctrl_world_service import MockCtrlWorldService
+
+                self._client = MockCtrlWorldService()
+                logger.info("Using mock Ctrl-World service")
+            except ImportError as e:
+                logger.error(f"Failed to import mock Ctrl-World service: {e}")
+                raise
+        else:
+            try:
+                from external_experts.CtrlWorld.ctrl_world_client import CtrlWorldClient
+
+                self._client = CtrlWorldClient(server_url=self.server_url)
+                logger.info("Using real Ctrl-World service (local server)")
+            except ImportError as e:
+                logger.error(f"Failed to import Ctrl-World client: {e}")
+                raise
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "image_path": {
+                    "type": "string",
+                    "description": "Path to the initial observation image.",
+                },
+                "actions": {
+                    "type": "array",
+                    "description": (
+                        "Action sequence for rollout. Each action is a 7D list: "
+                        "[x, y, z, rx, ry, rz, gripper]."
+                    ),
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "minItems": 7,
+                        "maxItems": 7,
+                    },
+                },
+                "instruction": {
+                    "type": "string",
+                    "description": "Optional natural-language task instruction.",
+                    "default": "",
+                },
+                "task_type": {
+                    "type": "string",
+                    "description": "Ctrl-World task type.",
+                    "enum": SUPPORTED_TASK_TYPES,
+                    "default": "pickplace",
+                },
+            },
+            "required": ["image_path", "actions"],
+        }
+
+    def call(
+        self,
+        image_path: str,
+        actions: List[List[float]],
+        instruction: str = "",
+        task_type: str = "pickplace",
+    ) -> Dict[str, Any]:
+        try:
+            logger.info(
+                f"Generating Ctrl-World rollout: task={task_type}, "
+                f"actions={len(actions) if isinstance(actions, list) else 0}"
+            )
+
+            if not image_path.startswith("http") and not Path(image_path).exists():
+                return {"success": False, "error": f"Image file not found: {image_path}"}
+
+            if task_type not in SUPPORTED_TASK_TYPES:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Unknown task_type: {task_type}. "
+                        f"Supported task types: {SUPPORTED_TASK_TYPES}"
+                    ),
+                }
+
+            validation_error = self._validate_actions(actions)
+            if validation_error:
+                return {"success": False, "error": validation_error}
+
+            result = self._client.generate_trajectory(
+                image_path=image_path,
+                actions=actions,
+                instruction=instruction,
+                task_type=task_type,
+            )
+
+            if result and result.get("success"):
+                logger.info(f"Ctrl-World rollout generated: {result.get('output_path')}")
+                return {
+                    "success": True,
+                    "result": result,
+                    "output_path": result.get("output_path"),
+                }
+
+            error_msg = result.get("error", "Unknown error") if result else "No result returned"
+            logger.error(f"Ctrl-World generation failed: {error_msg}")
+            return {"success": False, "error": f"Ctrl-World generation failed: {error_msg}"}
+        except Exception as e:
+            logger.error(f"Ctrl-World tool error: {e}")
+            return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def _validate_actions(actions: Any) -> str:
+        if not isinstance(actions, list) or not actions:
+            return "actions must be a non-empty list"
+
+        for idx, action in enumerate(actions):
+            if not isinstance(action, list):
+                return f"actions[{idx}] must be a list of 7 numbers"
+            if len(action) != 7:
+                return f"actions[{idx}] must contain exactly 7 values"
+            for value in action:
+                if not isinstance(value, (int, float)):
+                    return f"actions[{idx}] must contain numeric values only"
+        return ""

--- a/test/ctrl_world/test_ctrl_world_tool.py
+++ b/test/ctrl_world/test_ctrl_world_tool.py
@@ -1,0 +1,103 @@
+"""
+Tests for CtrlWorldTool - controllable world-model rollout generation.
+
+Usage:
+  # Mock test
+  python test/ctrl_world/test_ctrl_world_tool.py --use_mock --image_path assets/example.png
+
+  # Real server test
+  python test/ctrl_world/test_ctrl_world_tool.py --image_path assets/example.png --server_url http://localhost:20040
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "spagent"))
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def build_default_actions(num_waypoints: int):
+    # [x, y, z, rx, ry, rz, gripper] — length of list is caller-controlled (server uses its own pred_step etc.)
+    base = [0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 0.8]
+    return [base[:] for _ in range(num_waypoints)]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test CtrlWorldTool")
+    parser.add_argument(
+        "--use_mock",
+        action="store_true",
+        default=False,
+        help="Use mock service instead of real Ctrl-World server",
+    )
+    parser.add_argument(
+        "--image_path",
+        type=str,
+        default="assets/example.png",
+        help="Path to initial observation image",
+    )
+    parser.add_argument(
+        "--instruction",
+        type=str,
+        default="pick up the blue block and place in white plate",
+        help="Task instruction",
+    )
+    parser.add_argument(
+        "--task_type",
+        type=str,
+        default="pickplace",
+        choices=[
+            "replay",
+            "keyboard",
+            "pickplace",
+            "towel_fold",
+            "wipe_table",
+            "tissue",
+            "close_laptop",
+            "stack",
+            "drawer",
+        ],
+        help="Ctrl-World task type",
+    )
+    parser.add_argument(
+        "--num_actions",
+        type=int,
+        default=5,
+        help="Number of 7D poses in the test action sequence",
+    )
+    parser.add_argument(
+        "--server_url",
+        type=str,
+        default="http://localhost:20040",
+        help="Ctrl-World server URL (real mode only)",
+    )
+    args = parser.parse_args()
+
+    from tools.ctrl_world_tool import CtrlWorldTool
+
+    tool = CtrlWorldTool(use_mock=args.use_mock, server_url=args.server_url)
+    logger.info(f"CtrlWorldTool initialized (mock={args.use_mock}, server={args.server_url})")
+
+    actions = build_default_actions(args.num_actions)
+    result = tool.call(
+        image_path=args.image_path,
+        actions=actions,
+        instruction=args.instruction,
+        task_type=args.task_type,
+    )
+
+    if result["success"]:
+        logger.info(f"[PASS] Rollout generated: {result['output_path']}")
+        if result.get("result", {}).get("mock"):
+            logger.info("  (mock output)")
+    else:
+        logger.error(f"[FAIL] {result['error']}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add Ctrl-World integration to SPAgent as a new world-model rollout tool for trajectory/video generation from an initial image and 7D action sequence.
## Changes
- Added `spagent/external_experts/CtrlWorld/` with `CtrlWorldClient` and `MockCtrlWorldService`
- Added `spagent/tools/ctrl_world_tool.py` (name: `world_model_ctrl_world_tool`)
- Registered `CtrlWorldTool` in `spagent/tools/__init__.py`
- Added scheduler auto-registration entry in `plugin/plugin.py`
- Added `test/ctrl_world/test_ctrl_world_tool.py` (supports `--use_mock`, `--image_path`, `--task_type`, `--instruction`, `--num_actions`, `--server_url`)
## Notes
- Task types are aligned with Ctrl-World config (`replay`, `keyboard`, `pickplace`, `towel_fold`, `wipe_table`, `tissue`, `close_laptop`, `stack`, `drawer`)
- Action schema is validated as 7D `[x, y, z, rx, ry, rz, gripper]` per step
## Testing
- [x] Mock test passed
- [ ] Real Ctrl-World server test (pending server/checkpoint setup)