### PR TITLE
Feat/molmo2 integratioAdd Molmo2 external expert integration with tool/client/server/mock supportn

### DIFF
--- a/docs/Tool/TOOL_USING.md
+++ b/docs/Tool/TOOL_USING.md
@@ -38,6 +38,7 @@ external_experts/
 | **SAM2** | `SegmentationTool` | Image/Video Segmentation | High-precision segmentation tasks, precisely segment objects in images | Server (port 20020) | `image_path`, `point_coords`(optional), `point_labels`(optional), `box`(optional) |
 | **GroundingDINO** | `ObjectDetectionTool` | Open-vocabulary Object Detection | Detect arbitrary objects based on text descriptions | Server (port 20022) | `image_path`, `text_prompt`, `box_threshold`, `text_threshold` |
 | **Moondream** | `MoondreamTool` | Vision Language Model | Image understanding and Q&A, answer natural language questions based on image content | Server (port 20024) | `image_path`, `task`, `object_name` |
+| **Molmo2** | `Molmo2Tool` | Multimodal Reasoning & Point Grounding | Run Molmo2 through a local service for image QA, captioning, multi-image comparison, and point grounding with optional annotated outputs | Server (port 20035) | `image_path`, `task`, `prompt`, `save_annotated`(optional) |
 | **Pi3** | `Pi3Tool` | 3D Reconstruction | Generate 3D point clouds and multi-view rendered images from images | Server (port 20030) | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **Pi3X** | `Pi3XTool` | 3D Reconstruction (Enhanced) | Upgraded Pi3 with smoother point clouds, metric scale, and optional multimodal conditioning | Server (port 20031) | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **VGGT** | `VGGTTool` | Multi-view 3D Reconstruction & Camera Pose Estimation | Reconstruct 3D point clouds and estimate camera poses from multiple images or video frames | 20032 | `image_paths`, `azimuth_angle`, `elevation_angle`, `rotation_reference_camera`, `camera_view` |
@@ -241,6 +242,87 @@ export MOONDREAM_API_KEY="your_api_key"
 **Resources**:
 - [Official Website](https://moondream.ai/)
 - [API Documentation](https://docs.moondream.ai/)
+
+---
+
+### 4.1 Molmo2 - Multimodal Reasoning & Point Grounding Service
+
+**Function**: Run Molmo2 through a local service for image question answering, captioning, multi-image comparison, and point-driven grounding.
+
+**Features**:
+- Follows the same deployment pattern as other heavy SPAgent tools: local server + HTTP client + mock service
+- Supports single-image and multi-image prompts
+- Supports point grounding with optional annotated image outputs
+- Mock mode is available for development and testing
+
+**File Structure**:
+```text
+spagent/external_experts/Molmo2/
+├── molmo2_server.py
+├── molmo2_client.py
+├── molmo2_local.py
+├── mock_molmo2_service.py
+├── point_utils.py
+└── __init__.py
+```
+
+**Recommended Installation**:
+```bash
+pip install -r requirements.txt
+pip install ai2-molmo2 accelerate sentencepiece
+```
+
+Or install from source:
+```bash
+git clone https://github.com/allenai/molmo2.git
+cd molmo2
+pip install torchcodec
+pip install -e .[all]
+```
+
+**Start Server**:
+```bash
+python spagent/external_experts/Molmo2/molmo2_server.py \
+    --checkpoint allenai/Molmo2-4B \
+    --port 20035
+```
+
+**Python Example**:
+```python
+from spagent.tools import Molmo2Tool
+
+tool = Molmo2Tool(
+    use_mock=False,
+    server_url="http://localhost:20035",
+)
+
+qa_result = tool.call(
+    image_path="assets/dog.jpeg",
+    task="qa",
+    prompt="What animal is shown here?",
+)
+print(qa_result["response_text"])
+
+point_result = tool.call(
+    image_path="assets/dog.jpeg",
+    task="point",
+    prompt="Point to the dog.",
+    save_annotated=True,
+)
+print(point_result["result"]["points_by_image"])
+print(point_result["output_path"])  # system temp dir by default unless output_dir is set
+```
+
+**Direct Tool Test**:
+```bash
+python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20035
+python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task point --prompt "Point to the dog" --use_mock --save_annotated
+```
+
+**Resources**:
+- [Official Repository](https://github.com/allenai/molmo2)
+- [Paper](https://arxiv.org/abs/2601.10611)
+- [Hugging Face Models](https://huggingface.co/collections/allenai/molmo2)
 
 ---
 
@@ -847,6 +929,7 @@ Ensure necessary dependencies are installed:
 apt-get install tmux
 pip install torch torchvision
 pip install groundingdino_py supervision moondream
+pip install ai2-molmo2 accelerate sentencepiece
 ```
 
 Create checkpoints directory:
@@ -909,4 +992,9 @@ python spagent/external_experts/OrientAnythingV2/oa_v2_server.py \
 # Vision language model service
 python spagent/external_experts/moondream/md_server.py \
   --port 20024
+
+# Molmo2 multimodal reasoning service
+python spagent/external_experts/Molmo2/molmo2_server.py \
+  --checkpoint allenai/Molmo2-4B \
+  --port 20035
 ```

--- a/docs/Tool/TOOL_USING.md
+++ b/docs/Tool/TOOL_USING.md
@@ -38,7 +38,7 @@ external_experts/
 | **SAM2** | `SegmentationTool` | Image/Video Segmentation | High-precision segmentation tasks, precisely segment objects in images | Server (port 20020) | `image_path`, `point_coords`(optional), `point_labels`(optional), `box`(optional) |
 | **GroundingDINO** | `ObjectDetectionTool` | Open-vocabulary Object Detection | Detect arbitrary objects based on text descriptions | Server (port 20022) | `image_path`, `text_prompt`, `box_threshold`, `text_threshold` |
 | **Moondream** | `MoondreamTool` | Vision Language Model | Image understanding and Q&A, answer natural language questions based on image content | Server (port 20024) | `image_path`, `task`, `object_name` |
-| **Molmo2** | `Molmo2Tool` | Multimodal Reasoning & Point Grounding | Run Molmo2 through a local service for image QA, captioning, multi-image comparison, and point grounding with optional annotated outputs | Server (port 20035) | `image_path`, `task`, `prompt`, `save_annotated`(optional) |
+| **Molmo2** | `Molmo2Tool` | Multimodal Reasoning & Point Grounding | Run Molmo2 through a local service for image QA, captioning, and point grounding with optional annotated outputs | Server (port 20025) | `image_path`, `task`, `prompt`(optional), `save_annotated`(optional), `max_new_tokens`(optional) |
 | **Pi3** | `Pi3Tool` | 3D Reconstruction | Generate 3D point clouds and multi-view rendered images from images | Server (port 20030) | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **Pi3X** | `Pi3XTool` | 3D Reconstruction (Enhanced) | Upgraded Pi3 with smoother point clouds, metric scale, and optional multimodal conditioning | Server (port 20031) | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **VGGT** | `VGGTTool` | Multi-view 3D Reconstruction & Camera Pose Estimation | Reconstruct 3D point clouds and estimate camera poses from multiple images or video frames | 20032 | `image_paths`, `azimuth_angle`, `elevation_angle`, `rotation_reference_camera`, `camera_view` |
@@ -247,20 +247,20 @@ export MOONDREAM_API_KEY="your_api_key"
 
 ### 4.1 Molmo2 - Multimodal Reasoning & Point Grounding Service
 
-**Function**: Run Molmo2 through a local service for image question answering, captioning, multi-image comparison, and point-driven grounding.
+**Function**: Run Molmo2 through a local service for image question answering, captioning, and point-driven grounding.
 
 **Features**:
 - Follows the same deployment pattern as other heavy SPAgent tools: local server + HTTP client + mock service
-- Supports single-image and multi-image prompts
+- Supports three task modes: `qa`, `caption`, and `point`
 - Supports point grounding with optional annotated image outputs
 - Mock mode is available for development and testing
 
 **File Structure**:
 ```text
 spagent/external_experts/Molmo2/
+├── download_weights.py
 ├── molmo2_server.py
 ├── molmo2_client.py
-├── molmo2_local.py
 ├── mock_molmo2_service.py
 ├── point_utils.py
 └── __init__.py
@@ -269,10 +269,10 @@ spagent/external_experts/Molmo2/
 **Recommended Installation**:
 ```bash
 pip install -r requirements.txt
-pip install ai2-molmo2 accelerate sentencepiece
+pip install "transformers>=4.57,<5" accelerate sentencepiece huggingface_hub
 ```
 
-Or install from source:
+Optional upstream install:
 ```bash
 git clone https://github.com/allenai/molmo2.git
 cd molmo2
@@ -280,12 +280,38 @@ pip install torchcodec
 pip install -e .[all]
 ```
 
+**Download Weights**:
+```bash
+# Download a Hugging Face snapshot locally
+python spagent/external_experts/Molmo2/download_weights.py \
+    --repo allenai/Molmo2-4B \
+    --local-dir checkpoints/molmo2/Molmo2-4B
+
+# Point the server at the downloaded directory
+export MOLMO2_MODEL=checkpoints/molmo2/Molmo2-4B
+```
+
 **Start Server**:
 ```bash
 python spagent/external_experts/Molmo2/molmo2_server.py \
     --checkpoint allenai/Molmo2-4B \
-    --port 20035
+    --port 20025
 ```
+
+**Parameters**:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image_path` | string | ✅ | — | Path to the input image |
+| `task` | string | ❌ | `"qa"` | One of `qa`, `caption`, or `point` |
+| `prompt` | string | ❌ | task-specific default | Question, caption instruction, or pointing instruction |
+| `save_annotated` | boolean | ❌ | `True` | Save annotated point-grounding outputs when `task="point"` |
+| `max_new_tokens` | integer | ❌ | `200` | Maximum generation length for Molmo2 responses |
+
+Default prompts:
+- `qa`: `What do you see in this image? Answer briefly.`
+- `caption`: `Describe this image.`
+- `point`: `Point to the requested location. Output pointing coordinates in the model's standard format.`
 
 **Python Example**:
 ```python
@@ -293,15 +319,23 @@ from spagent.tools import Molmo2Tool
 
 tool = Molmo2Tool(
     use_mock=False,
-    server_url="http://localhost:20035",
+    server_url="http://localhost:20025",
+    output_dir="outputs/molmo2",
 )
 
 qa_result = tool.call(
     image_path="assets/dog.jpeg",
     task="qa",
     prompt="What animal is shown here?",
+    max_new_tokens=64,
 )
 print(qa_result["response_text"])
+
+caption_result = tool.call(
+    image_path="assets/dog.jpeg",
+    task="caption",
+)
+print(caption_result["response_text"])
 
 point_result = tool.call(
     image_path="assets/dog.jpeg",
@@ -315,8 +349,13 @@ print(point_result["output_path"])  # system temp dir by default unless output_d
 
 **Direct Tool Test**:
 ```bash
-python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20035
+python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20025
+python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task caption --server_url http://localhost:20025
 python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task point --prompt "Point to the dog" --use_mock --save_annotated
+
+# Unit tests
+pytest test/test_molmo2_tool.py -v
+python -m unittest test.test_molmo2_expert -v
 ```
 
 **Resources**:
@@ -996,5 +1035,5 @@ python spagent/external_experts/moondream/md_server.py \
 # Molmo2 multimodal reasoning service
 python spagent/external_experts/Molmo2/molmo2_server.py \
   --checkpoint allenai/Molmo2-4B \
-  --port 20035
+  --port 20025
 ```

--- a/docs/Tool/TOOL_USING_ZH.md
+++ b/docs/Tool/TOOL_USING_ZH.md
@@ -36,6 +36,7 @@ external_experts/
 | **SAM2** | `SegmentationTool` | 图像/视频分割 | 高精度分割任务，精确分割图像中的对象 | 本地服务器（20020） | `image_path`, `point_coords`(可选), `point_labels`(可选), `box`(可选) |
 | **GroundingDINO** | `ObjectDetectionTool` | 开放词汇目标检测 | 基于文本描述检测任意物体 | 本地服务器（20022） | `image_path`, `text_prompt`, `box_threshold`, `text_threshold` |
 | **Moondream** | `MoondreamTool` | 视觉语言模型 | 图像理解和问答，基于图像内容回答自然语言问题 | 本地服务器（20024） | `image_path`, `task`, `object_name` |
+| **Molmo2** | `Molmo2Tool` | 多模态推理与点选定位 | 通过本地 Molmo2 服务执行图像问答、描述、多图比较和 point grounding，可选保存标注图 | 本地服务器（20035） | `image_path`, `task`, `prompt`, `save_annotated`(可选) |
 | **Pi3** | `Pi3Tool` | 3D重建 | 从图像生成3D点云和多视角渲染图 | 本地服务器（20030） | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **Pi3X** | `Pi3XTool` | 3D重建（增强版） | Pi3升级版，更平滑点云、近似度量尺度、可选多模态条件注入 | 本地服务器（20031） | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **VGGT** | `VGGTTool` | 多视角3D重建与相机位姿估计 | 从多张图像或视频帧重建3D点云并估计相机位姿 | 20032 | `image_paths`, `azimuth_angle`, `elevation_angle`, `rotation_reference_camera`, `camera_view` |
@@ -218,6 +219,87 @@ export MOONDREAM_API_KEY="your_api_key"
 **资源链接**:
 - [官方网站](https://moondream.ai/)
 - [API文档](https://docs.moondream.ai/)
+
+---
+
+### 4.1 Molmo2 - 多模态推理与点选定位服务
+
+**功能**: 通过本地 Molmo2 服务执行图像问答、图像描述、多图比较和 point grounding。
+
+**特点**:
+- 与项目里的其他重型工具保持一致，采用本地 server + HTTP client + mock service 的方式
+- 支持单图和多图输入
+- 支持 point grounding，并可选保存标注图
+- 提供 mock 模式，便于开发和测试
+
+**文件结构**:
+```text
+spagent/external_experts/Molmo2/
+├── molmo2_server.py
+├── molmo2_client.py
+├── molmo2_local.py
+├── mock_molmo2_service.py
+├── point_utils.py
+└── __init__.py
+```
+
+**推荐安装**:
+```bash
+pip install -r requirements.txt
+pip install ai2-molmo2 accelerate sentencepiece
+```
+
+或参考官方源码安装:
+```bash
+git clone https://github.com/allenai/molmo2.git
+cd molmo2
+pip install torchcodec
+pip install -e .[all]
+```
+
+**启动服务**:
+```bash
+python spagent/external_experts/Molmo2/molmo2_server.py \
+    --checkpoint allenai/Molmo2-4B \
+    --port 20035
+```
+
+**Python 示例**:
+```python
+from spagent.tools import Molmo2Tool
+
+tool = Molmo2Tool(
+    use_mock=False,
+    server_url="http://localhost:20035",
+)
+
+qa_result = tool.call(
+    image_path="assets/dog.jpeg",
+    task="qa",
+    prompt="图中是什么动物？",
+)
+print(qa_result["response_text"])
+
+point_result = tool.call(
+    image_path="assets/dog.jpeg",
+    task="point",
+    prompt="请指向这只狗。",
+    save_annotated=True,
+)
+print(point_result["result"]["points_by_image"])
+print(point_result["output_path"])  # 默认保存在系统临时目录，除非显式设置 output_dir
+```
+
+**直接测试**:
+```bash
+python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20035
+python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task point --prompt "Point to the dog" --use_mock --save_annotated
+```
+
+**资源链接**:
+- [官方仓库](https://github.com/allenai/molmo2)
+- [论文](https://arxiv.org/abs/2601.10611)
+- [Hugging Face Models](https://huggingface.co/collections/allenai/molmo2)
 
 ---
 
@@ -827,6 +909,7 @@ result = tool.call(
 apt-get install tmux
 pip install torch torchvision
 pip install groundingdino_py supervision moondream
+pip install ai2-molmo2 accelerate sentencepiece
 ```
 
 创建checkpoints目录：
@@ -887,4 +970,9 @@ python spagent/external_experts/OrientAnythingV2/oa_v2_server.py \
 # 视觉语言模型服务
 python spagent/external_experts/moondream/md_server.py \
   --port 20024
+
+# Molmo2 多模态推理服务
+python spagent/external_experts/Molmo2/molmo2_server.py \
+  --checkpoint allenai/Molmo2-4B \
+  --port 20035
 ```

--- a/docs/Tool/TOOL_USING_ZH.md
+++ b/docs/Tool/TOOL_USING_ZH.md
@@ -36,7 +36,7 @@ external_experts/
 | **SAM2** | `SegmentationTool` | 图像/视频分割 | 高精度分割任务，精确分割图像中的对象 | 本地服务器（20020） | `image_path`, `point_coords`(可选), `point_labels`(可选), `box`(可选) |
 | **GroundingDINO** | `ObjectDetectionTool` | 开放词汇目标检测 | 基于文本描述检测任意物体 | 本地服务器（20022） | `image_path`, `text_prompt`, `box_threshold`, `text_threshold` |
 | **Moondream** | `MoondreamTool` | 视觉语言模型 | 图像理解和问答，基于图像内容回答自然语言问题 | 本地服务器（20024） | `image_path`, `task`, `object_name` |
-| **Molmo2** | `Molmo2Tool` | 多模态推理与点选定位 | 通过本地 Molmo2 服务执行图像问答、描述、多图比较和 point grounding，可选保存标注图 | 本地服务器（20035） | `image_path`, `task`, `prompt`, `save_annotated`(可选) |
+| **Molmo2** | `Molmo2Tool` | 多模态推理与点选定位 | 通过本地 Molmo2 服务执行图像问答、描述和 point grounding，可选保存标注图 | 本地服务器（20025） | `image_path`, `task`, `prompt`(可选), `save_annotated`(可选), `max_new_tokens`(可选) |
 | **Pi3** | `Pi3Tool` | 3D重建 | 从图像生成3D点云和多视角渲染图 | 本地服务器（20030） | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **Pi3X** | `Pi3XTool` | 3D重建（增强版） | Pi3升级版，更平滑点云、近似度量尺度、可选多模态条件注入 | 本地服务器（20031） | `image_path`, `azimuth_angle`, `elevation_angle` |
 | **VGGT** | `VGGTTool` | 多视角3D重建与相机位姿估计 | 从多张图像或视频帧重建3D点云并估计相机位姿 | 20032 | `image_paths`, `azimuth_angle`, `elevation_angle`, `rotation_reference_camera`, `camera_view` |
@@ -224,20 +224,20 @@ export MOONDREAM_API_KEY="your_api_key"
 
 ### 4.1 Molmo2 - 多模态推理与点选定位服务
 
-**功能**: 通过本地 Molmo2 服务执行图像问答、图像描述、多图比较和 point grounding。
+**功能**: 通过本地 Molmo2 服务执行图像问答、图像描述和 point grounding。
 
 **特点**:
 - 与项目里的其他重型工具保持一致，采用本地 server + HTTP client + mock service 的方式
-- 支持单图和多图输入
+- 支持三种任务模式：`qa`、`caption`、`point`
 - 支持 point grounding，并可选保存标注图
 - 提供 mock 模式，便于开发和测试
 
 **文件结构**:
 ```text
 spagent/external_experts/Molmo2/
+├── download_weights.py
 ├── molmo2_server.py
 ├── molmo2_client.py
-├── molmo2_local.py
 ├── mock_molmo2_service.py
 ├── point_utils.py
 └── __init__.py
@@ -246,15 +246,26 @@ spagent/external_experts/Molmo2/
 **推荐安装**:
 ```bash
 pip install -r requirements.txt
-pip install ai2-molmo2 accelerate sentencepiece
+pip install "transformers>=4.57,<5" accelerate sentencepiece huggingface_hub
 ```
 
-或参考官方源码安装:
+如需参考上游源码安装:
 ```bash
 git clone https://github.com/allenai/molmo2.git
 cd molmo2
 pip install torchcodec
 pip install -e .[all]
+```
+
+**下载权重**:
+```bash
+# 将 Hugging Face 模型快照下载到本地目录
+python spagent/external_experts/Molmo2/download_weights.py \
+    --repo allenai/Molmo2-4B \
+    --local-dir checkpoints/molmo2/Molmo2-4B
+
+# 启动服务前指定模型目录
+export MOLMO2_MODEL=checkpoints/molmo2/Molmo2-4B
 ```
 
 **启动服务**:
@@ -264,21 +275,44 @@ python spagent/external_experts/Molmo2/molmo2_server.py \
     --port 20035
 ```
 
+**参数说明**:
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `image_path` | string | ✅ | — | 输入图片路径 |
+| `task` | string | ❌ | `"qa"` | `qa`、`caption`、`point` 三选一 |
+| `prompt` | string | ❌ | 按任务自动填充 | 问答问题、描述指令或 point 指令 |
+| `save_annotated` | boolean | ❌ | `True` | 当 `task="point"` 时是否保存标注图 |
+| `max_new_tokens` | integer | ❌ | `200` | Molmo2 输出的最大生成长度 |
+
+默认提示词：
+- `qa`: `What do you see in this image? Answer briefly.`
+- `caption`: `Describe this image.`
+- `point`: `Point to the requested location. Output pointing coordinates in the model's standard format.`
+
 **Python 示例**:
 ```python
 from spagent.tools import Molmo2Tool
 
 tool = Molmo2Tool(
     use_mock=False,
-    server_url="http://localhost:20035",
+    server_url="http://localhost:20025",
+    output_dir="outputs/molmo2",
 )
 
 qa_result = tool.call(
     image_path="assets/dog.jpeg",
     task="qa",
     prompt="图中是什么动物？",
+    max_new_tokens=64,
 )
 print(qa_result["response_text"])
+
+caption_result = tool.call(
+    image_path="assets/dog.jpeg",
+    task="caption",
+)
+print(caption_result["response_text"])
 
 point_result = tool.call(
     image_path="assets/dog.jpeg",
@@ -293,7 +327,12 @@ print(point_result["output_path"])  # 默认保存在系统临时目录，除非
 **直接测试**:
 ```bash
 python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20035
+python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task caption --server_url http://localhost:20035
 python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task point --prompt "Point to the dog" --use_mock --save_annotated
+
+# 单元测试
+pytest test/test_molmo2_tool.py -v
+python -m unittest test.test_molmo2_expert -v
 ```
 
 **资源链接**:
@@ -974,5 +1013,5 @@ python spagent/external_experts/moondream/md_server.py \
 # Molmo2 多模态推理服务
 python spagent/external_experts/Molmo2/molmo2_server.py \
   --checkpoint allenai/Molmo2-4B \
-  --port 20035
+  --port 20025
 ```

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -1338,6 +1338,7 @@ class SPAgentToolCallingScheduler(MultiTurnScheduler):
             ('SegmentationTool', 'segmentation_tool'),
             ('ObjectDetectionTool', 'object_detection_tool'),
             ('Pi3Tool', 'pi3_tool'),
+            ('Molmo2Tool', 'molmo2_tool'),
             ('VeoTool', 'video_generation_veo_tool'),
             ('SoraTool', 'video_generation_sora_tool'),
             ('QwenVLTool', 'qwenvl_detection_tool'),

--- a/readme.md
+++ b/readme.md
@@ -59,15 +59,15 @@ We introduce **SPAgent**, a foundation agent designed for perception, reasoning,
 | Module | Path | Description |
 |--------|------|-------------|
 | **SPAgent Core** | `spagent/core/` | Core agent architecture:<br>- SPAgent class and agent logic<br>- Tool base classes and registry<br>- Model base classes and wrappers<br>- Unified prompt system (built-in `SPATIAL_3D_SYSTEM_PROMPT` / `GENERAL_VISION_SYSTEM_PROMPT` templates, fully customisable via `system_prompt` parameter)<br>- Data collection utilities |
-| **Tools** | `spagent/tools/` | Modular expert tool implementations:<br>- DepthEstimationTool<br>- SegmentationTool<br>- ObjectDetectionTool<br>- SupervisionTool<br>- YOLOETool<br>- MoondreamTool<br>- Pi3Tool<br>- Pi3XTool<br>- VGGTTool<br>- MapAnythingTool<br>- **YOLO26Tool** (local YOLO26 object detection, no server needed)<br>- **VeoTool** (Google Veo, API-based)<br>- **SoraTool** (OpenAI Sora, API-based)<br>- **WanTool** (Alibaba Wan, API-based) |
+| **Tools** | `spagent/tools/` | Modular expert tool implementations:<br>- DepthEstimationTool<br>- SegmentationTool<br>- ObjectDetectionTool<br>- SupervisionTool<br>- YOLOETool<br>- MoondreamTool<br>- **Molmo2Tool** (multimodal reasoning and point grounding)<br>- Pi3Tool<br>- Pi3XTool<br>- VGGTTool<br>- MapAnythingTool<br>- **YOLO26Tool** (local YOLO26 object detection, no server needed)<br>- **VeoTool** (Google Veo, API-based)<br>- **SoraTool** (OpenAI Sora, API-based)<br>- **WanTool** (Alibaba Wan, API-based) |
 | **Models** | `spagent/models/` | Model wrappers for different backends:<br>- GPTModel (OpenAI API)<br>- QwenModel (DashScope API)<br>- QwenVLLMModel (local VLLM) |
-| **External Experts** | `spagent/external_experts/` | Specialized expert models with client/server architecture:<br>- Depth Estimation (**Depth-AnythingV2**)<br>- Image/Video Segmentation (**SAM2**)<br>- Open-vocabulary Detection (**GroundingDINO** / **Qwen2.5-VL**)<br>- Vision Language Model (**Moondream**)<br>- 3D Point Cloud Reconstruction (**Pi3** / **Pi3X**)<br>- Multi-view 3D Reconstruction & Pose Estimation (**VGGT**)<br>- Dense 3D Reconstruction via Depth Estimation (**MapAnything**)<br>- YOLO-E Detection & Annotation (**Supervision**)<br>- Video Generation (**Veo** / **Sora** / **WAN**, API-based, no local server needed)<br>- Each includes client/server implementations and can run as external APIs |
-| **Tools** | `spagent/tools/` | Modular expert tool implementations:<br>- DepthEstimationTool<br>- SegmentationTool<br>- ObjectDetectionTool<br>- SupervisionTool<br>- YOLOETool<br>- MoondreamTool<br>- Pi3Tool<br>- Pi3XTool<br>- VGGTTool<br>- MapAnythingTool<br>- **OrientAnythingV2Tool** (orientation \& rotation estimation)<br>- **VeoTool** (Google Veo, API-based)<br>- **SoraTool** (OpenAI Sora, API-based) |
+| **External Experts** | `spagent/external_experts/` | Specialized expert models with client/server architecture:<br>- Depth Estimation (**Depth-AnythingV2**)<br>- Image/Video Segmentation (**SAM2**)<br>- Open-vocabulary Detection (**GroundingDINO** / **Qwen2.5-VL**)<br>- Vision Language Model (**Moondream** / **Molmo2**)<br>- 3D Point Cloud Reconstruction (**Pi3** / **Pi3X**)<br>- Multi-view 3D Reconstruction & Pose Estimation (**VGGT**)<br>- Dense 3D Reconstruction via Depth Estimation (**MapAnything**)<br>- YOLO-E Detection & Annotation (**Supervision**)<br>- Video Generation (**Veo** / **Sora** / **WAN**, API-based, no local server needed)<br>- Each includes client/server implementations and can run as external APIs |
+| **Tools** | `spagent/tools/` | Modular expert tool implementations:<br>- DepthEstimationTool<br>- SegmentationTool<br>- ObjectDetectionTool<br>- SupervisionTool<br>- YOLOETool<br>- MoondreamTool<br>- **Molmo2Tool** (multimodal reasoning and point grounding)<br>- Pi3Tool<br>- Pi3XTool<br>- VGGTTool<br>- MapAnythingTool<br>- **OrientAnythingV2Tool** (orientation \& rotation estimation)<br>- **VeoTool** (Google Veo, API-based)<br>- **SoraTool** (OpenAI Sora, API-based) |
 | **Models** | `spagent/models/` | Model wrappers for different backends:<br>- GPTModel (OpenAI API)<br>- QwenModel (DashScope API)<br>- QwenVLLMModel (local VLLM) |
-| **External Experts** | `spagent/external_experts/` | Specialized expert models with client/server architecture:<br>- Depth Estimation (**Depth-AnythingV2**)<br>- Image/Video Segmentation (**SAM2**)<br>- Open-vocabulary Detection (**GroundingDINO**)<br>- Vision Language Model (**Moondream**)<br>- 3D Point Cloud Reconstruction (**Pi3** / **Pi3X**)<br>- Multi-view 3D Reconstruction & Pose Estimation (**VGGT**)<br>- Dense 3D Reconstruction via Depth Estimation (**MapAnything**)<br>- YOLO-E Detection & Annotation (**Supervision**)<br>- Object Orientation & Rotation Estimation (**OrientAnythingV2**, NeurIPS 2025 Spotlight)<br>- Video Generation (**Veo** / **Sora**, API-based, no local server needed)<br>- Each includes client/server implementations and can run as external APIs |
+| **External Experts** | `spagent/external_experts/` | Specialized expert models with client/server architecture:<br>- Depth Estimation (**Depth-AnythingV2**)<br>- Image/Video Segmentation (**SAM2**)<br>- Open-vocabulary Detection (**GroundingDINO**)<br>- Vision Language Model (**Moondream** / **Molmo2**)<br>- 3D Point Cloud Reconstruction (**Pi3** / **Pi3X**)<br>- Multi-view 3D Reconstruction & Pose Estimation (**VGGT**)<br>- Dense 3D Reconstruction via Depth Estimation (**MapAnything**)<br>- YOLO-E Detection & Annotation (**Supervision**)<br>- Object Orientation & Rotation Estimation (**OrientAnythingV2**, NeurIPS 2025 Spotlight)<br>- Video Generation (**Veo** / **Sora**, API-based, no local server needed)<br>- Each includes client/server implementations and can run as external APIs |
 | **VLLM Models** | `spagent/vllm_models/` | VLLM inference utilities and wrappers:<br>- GPT API wrapper<br>- Qwen API wrapper<br>- Local VLLM inference for Qwen models |
 | **Examples** | `examples/` | Example scripts and usage tutorials:<br>- Evaluation scripts for datasets<br>- Quick start examples<br>- Tool definition examples |
-| **Test** | `test/` | Test scripts for tools and models:<br>- Direct tool testing without LLM Agent (`test_tool.py`) — supports Pi3, Depth, Segmentation, Detection, Veo, Sora<br>- Orient Anything V2 tool testing (`test_orient_anything_v2_tool.py`) — mock & real server modes<br>- Pi3 tool testing with video frame extraction (`test_pi3_llm.py`)<br>- System prompt construction verification (`test_prompt.py`) |
+| **Test** | `test/` | Test scripts for tools and models:<br>- Direct tool testing without LLM Agent (`test_tool.py`) — supports Pi3, Depth, Segmentation, Detection, Molmo2, Veo, Sora<br>- Molmo2 tool testing (`test_molmo2_tool.py`) — mock mode sanity checks<br>- Orient Anything V2 tool testing (`test_orient_anything_v2_tool.py`) — mock & real server modes<br>- Pi3 tool testing with video frame extraction (`test_pi3_llm.py`)<br>- System prompt construction verification (`test_prompt.py`) |
 | **Train** | `train/` | Reinforcement learning training scripts:<br>- GRPO training configurations<br>- LoRA merge and model compression utilities<br>- System prompts for different training modes |
 
 ## 🔍 External Experts
@@ -78,6 +78,7 @@ We introduce **SPAgent**, a foundation agent designed for perception, reasoning,
 | **SAM2** | 2D | Image Segmentation | Local server (20020) | Segment Anything Model 2nd generation, interactive or automatic segmentation |
 | **GroundingDINO** | 2D | Open-vocabulary Object Detection | Local server (20022) | Detect arbitrary objects based on text descriptions |
 | **Moondream** | 2D | Vision Language Model | Local server (20024) | Small and efficient visual Q&A model, supports image description and Q&A |
+| **Molmo2** | 2D | Multimodal Reasoning & Point Grounding | Local server (20035) | Molmo2 service for image QA, multi-image comparison, and point grounding with optional annotated outputs |
 | **Pi3** | 3D | 3D Point Cloud Reconstruction | Local server (20030) | Generate 3D point clouds and multi-view rendered images from images |
 | **Pi3X** | 3D | 3D Point Cloud Reconstruction (Enhanced) | Local server (20031) | Upgraded Pi3 with smoother point clouds, metric scale, and optional multimodal conditioning |
 | **VGGT** | 3D | Multi-view 3D Point Cloud Reconstruction & Camera Pose Estimation | 20032 | Reconstruct 3D point clouds and estimate camera extrinsics/intrinsics from multiple images using [facebook/VGGT-1B](https://huggingface.co/facebook/VGGT-1B); supports both image lists and video frame input |
@@ -127,6 +128,18 @@ export GCP_API_KEY="your_gcp_api_key"
 python spagent/vllm_models/qwen.py
 ```
 
+Optional for running the real Molmo2 service:
+
+```bash
+# Install Molmo2-compatible dependencies on the server host
+pip install ai2-molmo2 accelerate sentencepiece
+
+# Start the local Molmo2 service
+python spagent/external_experts/Molmo2/molmo2_server.py \
+    --checkpoint allenai/Molmo2-4B \
+    --port 20035
+```
+
 ### 3. Deploy External Expert Services
 
 For detailed external expert tools usage guide, please refer to: **[External Experts Tool Usage Guide](docs/Tool/TOOL_USING.md)**
@@ -168,6 +181,7 @@ from spagent.tools import (
     SupervisionTool,          # Supervision tool
     YOLOETool,                # YOLO-E detection
     MoondreamTool,            # Visual Q&A
+    Molmo2Tool,               # Molmo2 reasoning / pointing
     Pi3Tool,                  # 3D reconstruction
     Pi3XTool                  # 3D reconstruction (enhanced)
 )

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ We introduce **SPAgent**, a foundation agent designed for perception, reasoning,
 | **External Experts** | `spagent/external_experts/` | Specialized expert models with client/server architecture:<br>- Depth Estimation (**Depth-AnythingV2**)<br>- Image/Video Segmentation (**SAM2**)<br>- Open-vocabulary Detection (**GroundingDINO**)<br>- Vision Language Model (**Moondream** / **Molmo2**)<br>- 3D Point Cloud Reconstruction (**Pi3** / **Pi3X**)<br>- Multi-view 3D Reconstruction & Pose Estimation (**VGGT**)<br>- Dense 3D Reconstruction via Depth Estimation (**MapAnything**)<br>- YOLO-E Detection & Annotation (**Supervision**)<br>- Object Orientation & Rotation Estimation (**OrientAnythingV2**, NeurIPS 2025 Spotlight)<br>- Video Generation (**Veo** / **Sora**, API-based, no local server needed)<br>- Each includes client/server implementations and can run as external APIs |
 | **VLLM Models** | `spagent/vllm_models/` | VLLM inference utilities and wrappers:<br>- GPT API wrapper<br>- Qwen API wrapper<br>- Local VLLM inference for Qwen models |
 | **Examples** | `examples/` | Example scripts and usage tutorials:<br>- Evaluation scripts for datasets<br>- Quick start examples<br>- Tool definition examples |
-| **Test** | `test/` | Test scripts for tools and models:<br>- Direct tool testing without LLM Agent (`test_tool.py`) — supports Pi3, Depth, Segmentation, Detection, Molmo2, Veo, Sora<br>- Molmo2 tool testing (`test_molmo2_tool.py`) — mock mode sanity checks<br>- Orient Anything V2 tool testing (`test_orient_anything_v2_tool.py`) — mock & real server modes<br>- Pi3 tool testing with video frame extraction (`test_pi3_llm.py`)<br>- System prompt construction verification (`test_prompt.py`) |
+| **Test** | `test/` | Test scripts for tools and models:<br>- Direct tool testing without LLM Agent (`test_tool.py`) — supports Pi3, Depth, Segmentation, Detection, Molmo2, Veo, Sora<br>- Molmo2 tool testing (`test_molmo2_tool.py`) — mock mode and optional live server checks<br>- Molmo2 expert unit tests (`test_molmo2_expert.py`) — mock service and HTTP client coverage<br>- Orient Anything V2 tool testing (`test_orient_anything_v2_tool.py`) — mock & real server modes<br>- Pi3 tool testing with video frame extraction (`test_pi3_llm.py`)<br>- System prompt construction verification (`test_prompt.py`) |
 | **Train** | `train/` | Reinforcement learning training scripts:<br>- GRPO training configurations<br>- LoRA merge and model compression utilities<br>- System prompts for different training modes |
 
 ## 🔍 External Experts
@@ -78,7 +78,7 @@ We introduce **SPAgent**, a foundation agent designed for perception, reasoning,
 | **SAM2** | 2D | Image Segmentation | Local server (20020) | Segment Anything Model 2nd generation, interactive or automatic segmentation |
 | **GroundingDINO** | 2D | Open-vocabulary Object Detection | Local server (20022) | Detect arbitrary objects based on text descriptions |
 | **Moondream** | 2D | Vision Language Model | Local server (20024) | Small and efficient visual Q&A model, supports image description and Q&A |
-| **Molmo2** | 2D | Multimodal Reasoning & Point Grounding | Local server (20035) | Molmo2 service for image QA, multi-image comparison, and point grounding with optional annotated outputs |
+| **Molmo2** | 2D | Multimodal Reasoning & Point Grounding | Local server (20025) | Molmo2 service for `qa`, `caption`, and `point` tasks, with mock mode and optional annotated point outputs |
 | **Pi3** | 3D | 3D Point Cloud Reconstruction | Local server (20030) | Generate 3D point clouds and multi-view rendered images from images |
 | **Pi3X** | 3D | 3D Point Cloud Reconstruction (Enhanced) | Local server (20031) | Upgraded Pi3 with smoother point clouds, metric scale, and optional multimodal conditioning |
 | **VGGT** | 3D | Multi-view 3D Point Cloud Reconstruction & Camera Pose Estimation | 20032 | Reconstruct 3D point clouds and estimate camera extrinsics/intrinsics from multiple images using [facebook/VGGT-1B](https://huggingface.co/facebook/VGGT-1B); supports both image lists and video frame input |
@@ -128,17 +128,7 @@ export GCP_API_KEY="your_gcp_api_key"
 python spagent/vllm_models/qwen.py
 ```
 
-Optional for running the real Molmo2 service:
 
-```bash
-# Install Molmo2-compatible dependencies on the server host
-pip install ai2-molmo2 accelerate sentencepiece
-
-# Start the local Molmo2 service
-python spagent/external_experts/Molmo2/molmo2_server.py \
-    --checkpoint allenai/Molmo2-4B \
-    --port 20035
-```
 
 ### 3. Deploy External Expert Services
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-torch==2.5.1
-torchvision==0.20.1
+torch==2.6.0
+torchvision==0.21.0
+
+
 numpy==1.26.4
 plyfile
 huggingface_hub
@@ -17,7 +19,8 @@ pandas
 matplotlib
 scipy
 scikit-learn
-transformers
+transformers>=4.57.0,<5
+accelerate
 Flask
 clip
 datasets

--- a/spagent/external_experts/Molmo2/__init__.py
+++ b/spagent/external_experts/Molmo2/__init__.py
@@ -1,7 +1,11 @@
-"""Helpers for integrating Molmo2 with SPAgent."""
+"""
+Molmo2 vision-language expert (Allen AI).
 
-from .mock_molmo2_service import MockMolmo2Service
+- molmo2_server: Flask HTTP service loading HF checkpoints (e.g. allenai/Molmo2-4B).
+- molmo2_client: HTTP client for the service.
+- download_weights: snapshot_download helper for offline/air-gapped setups.
+"""
+
 from .molmo2_client import Molmo2Client
-from .molmo2_local import Molmo2LocalClient
 
-__all__ = ["MockMolmo2Service", "Molmo2Client", "Molmo2LocalClient"]
+__all__ = ["Molmo2Client"]

--- a/spagent/external_experts/Molmo2/__init__.py
+++ b/spagent/external_experts/Molmo2/__init__.py
@@ -1,0 +1,7 @@
+"""Helpers for integrating Molmo2 with SPAgent."""
+
+from .mock_molmo2_service import MockMolmo2Service
+from .molmo2_client import Molmo2Client
+from .molmo2_local import Molmo2LocalClient
+
+__all__ = ["MockMolmo2Service", "Molmo2Client", "Molmo2LocalClient"]

--- a/spagent/external_experts/Molmo2/download_weights.py
+++ b/spagent/external_experts/Molmo2/download_weights.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Download Molmo2 weights from Hugging Face into a local directory.
+
+Typical models: allenai/Molmo2-4B (smallest), allenai/Molmo2-8B, allenai/Molmo2-O-7B.
+See https://github.com/allenai/molmo2 for native .tar checkpoints and HF conversion.
+
+Usage:
+  python download_weights.py --local-dir /data/Molmo2-4B
+  python download_weights.py --repo allenai/Molmo2-8B --local-dir ./Molmo2-8B
+
+Then point the server at the directory:
+  export MOLMO2_MODEL=/data/Molmo2-4B
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from huggingface_hub import snapshot_download
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download Molmo2 weights from Hugging Face.")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("MOLMO2_REPO", "allenai/Molmo2-4B"),
+        help="Hugging Face repo id (default: allenai/Molmo2-4B or MOLMO2_REPO).",
+    )
+    parser.add_argument(
+        "--local-dir",
+        required=True,
+        help="Directory to store the snapshot (e.g. /data/Molmo2-4B).",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"),
+        help="HF token if needed (or set HF_TOKEN / HUGGING_FACE_HUB_TOKEN).",
+    )
+    args = parser.parse_args()
+
+    path = snapshot_download(
+        repo_id=args.repo,
+        local_dir=args.local_dir,
+        token=args.token,
+    )
+    print(f"Downloaded {args.repo} to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/spagent/external_experts/Molmo2/mock_molmo2_service.py
+++ b/spagent/external_experts/Molmo2/mock_molmo2_service.py
@@ -1,74 +1,18 @@
-"""Mock Molmo2 service compatible with the Molmo2 client/server flow."""
+"""Lightweight mock for Molmo2 tool tests without a GPU server."""
+
+from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List
-
-from .point_utils import (
-    annotate_images_as_base64,
-    extract_points_from_text,
-    group_points_by_image,
-    save_annotated_images,
-)
+from typing import Any, Dict
 
 
-class MockMolmo2Service:
-    """Lightweight Molmo2 mock used by tests and development."""
-
-    def __init__(self, output_dir=None):
-        self.output_dir = output_dir
-
-    def infer(
-        self,
-        image_paths: List[str],
-        task: str,
-        prompt: str,
-        max_new_tokens: int = 256,
-        temperature: float = 0.0,
-        save_annotated: bool = True,
-    ) -> Dict:
+class MockMolmo2:
+    def infer_path(self, image_path: str, prompt: str = "Describe this image.", max_new_tokens: int = 200) -> Dict[str, Any]:
         _ = max_new_tokens
-        _ = temperature
-
-        normalized = [str(Path(p)) for p in image_paths]
-        prompt_lower = prompt.lower()
-
-        if task == "point" or "point" in prompt_lower or "locat" in prompt_lower:
-            if len(normalized) == 1:
-                generated_text = '<points label="mock target" coords="1 1 500 500"/>'
-            else:
-                generated_text = '<points label="mock target" coords="1 1 420 420;2 2 580 580"/>'
-        elif "compare" in prompt_lower and len(normalized) > 1:
-            generated_text = (
-                "The first image appears more centered and closer to the camera, "
-                "while the second image shows a wider surrounding context."
-            )
-        else:
-            generated_text = (
-                "This is a mock Molmo2 response describing the main visual content "
-                "and answering the request at a high level."
-            )
-
-        result = {
+        if not Path(image_path).exists():
+            return {"success": False, "error": f"Image file not found: {image_path}"}
+        return {
             "success": True,
-            "generated_text": generated_text,
-            "task": task,
-            "image_paths": normalized,
+            "text": f"[mock] {prompt[:80]} on {Path(image_path).name}",
+            "model": "mock",
         }
-        if task == "point":
-            from PIL import Image
-
-            sizes = []
-            for path in normalized:
-                with Image.open(path) as image:
-                    sizes.append(image.size)
-            points = extract_points_from_text(generated_text, sizes)
-            grouped_points = group_points_by_image(points, normalized)
-            result["points_by_image"] = grouped_points
-            result["num_points"] = sum(len(group["points"]) for group in grouped_points)
-            if save_annotated:
-                annotated_images = annotate_images_as_base64(normalized, grouped_points)
-                output_paths = save_annotated_images(annotated_images, output_dir=self.output_dir)
-                result["annotated_images"] = annotated_images
-                result["output_paths"] = output_paths
-                result["output_path"] = output_paths[0] if output_paths else None
-        return result

--- a/spagent/external_experts/Molmo2/mock_molmo2_service.py
+++ b/spagent/external_experts/Molmo2/mock_molmo2_service.py
@@ -1,0 +1,74 @@
+"""Mock Molmo2 service compatible with the Molmo2 client/server flow."""
+
+from pathlib import Path
+from typing import Dict, List
+
+from .point_utils import (
+    annotate_images_as_base64,
+    extract_points_from_text,
+    group_points_by_image,
+    save_annotated_images,
+)
+
+
+class MockMolmo2Service:
+    """Lightweight Molmo2 mock used by tests and development."""
+
+    def __init__(self, output_dir=None):
+        self.output_dir = output_dir
+
+    def infer(
+        self,
+        image_paths: List[str],
+        task: str,
+        prompt: str,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+        save_annotated: bool = True,
+    ) -> Dict:
+        _ = max_new_tokens
+        _ = temperature
+
+        normalized = [str(Path(p)) for p in image_paths]
+        prompt_lower = prompt.lower()
+
+        if task == "point" or "point" in prompt_lower or "locat" in prompt_lower:
+            if len(normalized) == 1:
+                generated_text = '<points label="mock target" coords="1 1 500 500"/>'
+            else:
+                generated_text = '<points label="mock target" coords="1 1 420 420;2 2 580 580"/>'
+        elif "compare" in prompt_lower and len(normalized) > 1:
+            generated_text = (
+                "The first image appears more centered and closer to the camera, "
+                "while the second image shows a wider surrounding context."
+            )
+        else:
+            generated_text = (
+                "This is a mock Molmo2 response describing the main visual content "
+                "and answering the request at a high level."
+            )
+
+        result = {
+            "success": True,
+            "generated_text": generated_text,
+            "task": task,
+            "image_paths": normalized,
+        }
+        if task == "point":
+            from PIL import Image
+
+            sizes = []
+            for path in normalized:
+                with Image.open(path) as image:
+                    sizes.append(image.size)
+            points = extract_points_from_text(generated_text, sizes)
+            grouped_points = group_points_by_image(points, normalized)
+            result["points_by_image"] = grouped_points
+            result["num_points"] = sum(len(group["points"]) for group in grouped_points)
+            if save_annotated:
+                annotated_images = annotate_images_as_base64(normalized, grouped_points)
+                output_paths = save_annotated_images(annotated_images, output_dir=self.output_dir)
+                result["annotated_images"] = annotated_images
+                result["output_paths"] = output_paths
+                result["output_path"] = output_paths[0] if output_paths else None
+        return result

--- a/spagent/external_experts/Molmo2/molmo2_client.py
+++ b/spagent/external_experts/Molmo2/molmo2_client.py
@@ -1,83 +1,87 @@
-"""
-HTTP client for Molmo2 server.
-"""
-
 import base64
+import io
 import logging
-import mimetypes
+import os
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import requests
+from PIL import Image
 
-from .point_utils import save_annotated_images
+try:
+    import numpy as np
+except ImportError:
+    np = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
 
 class Molmo2Client:
-    """Client for a Molmo2 inference server."""
+    """HTTP client for the Molmo2 Flask server."""
 
-    def __init__(self, server_url: str = "http://localhost:20035", output_dir: Union[str, Path, None] = None):
-        self.server_url = server_url.rstrip("/")
-        self.output_dir = output_dir
+    def __init__(self, server_url: Optional[str] = None):
+        self.server_url = (server_url or os.environ.get("MOLMO2_SERVER_URL", "http://localhost:20025")).rstrip(
+            "/"
+        )
 
-    def health_check(self) -> Dict:
+    def _encode_image(self, image: Union[str, "np.ndarray", Image.Image]) -> str:
+        if isinstance(image, str):
+            with open(image, "rb") as f:
+                image_bytes = f.read()
+        elif np is not None and isinstance(image, np.ndarray):
+            try:
+                import cv2
+
+                _, buffer = cv2.imencode(".jpg", image)
+                image_bytes = buffer.tobytes()
+            except ImportError:
+                arr = image[..., ::-1] if image.ndim == 3 and image.shape[2] == 3 else image
+                buf = io.BytesIO()
+                Image.fromarray(arr).save(buf, format="JPEG")
+                image_bytes = buf.getvalue()
+        elif isinstance(image, Image.Image):
+            buffer = io.BytesIO()
+            image.save(buffer, format="JPEG")
+            image_bytes = buffer.getvalue()
+        else:
+            raise ValueError("Unsupported image type")
+        return base64.b64encode(image_bytes).decode("utf-8")
+
+    def health_check(self) -> Dict[str, Any]:
         try:
-            response = requests.get(f"{self.server_url}/health", timeout=10)
+            response = requests.get(f"{self.server_url}/health", timeout=30)
             response.raise_for_status()
             return response.json()
         except Exception as e:
             logger.error("Molmo2 health check failed: %s", e)
-            return {"success": False, "error": str(e)}
+            return {"status": "error", "error": str(e)}
 
     def infer(
         self,
-        image_paths: List[str],
-        task: str,
-        prompt: str,
-        max_new_tokens: int = 256,
-        temperature: float = 0.0,
-        save_annotated: bool = True,
-    ) -> Dict:
+        image: Union[str, np.ndarray, Image.Image],
+        prompt: str = "Describe this image.",
+        max_new_tokens: int = 200,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "image": self._encode_image(image),
+            "prompt": prompt,
+            "max_new_tokens": max_new_tokens,
+        }
         try:
-            payload = {
-                "images": [self._encode_image(path) for path in image_paths],
-                "image_names": [Path(path).name for path in image_paths],
-                "task": task,
-                "prompt": prompt,
-                "max_new_tokens": max_new_tokens,
-                "temperature": temperature,
-                "save_annotated": save_annotated,
-            }
             response = requests.post(
                 f"{self.server_url}/infer",
                 json=payload,
-                headers={"Content-Type": "application/json"},
-                timeout=300,
+                timeout=600,
             )
-            if not response.ok:
-                try:
-                    error_payload = response.json()
-                except ValueError:
-                    error_payload = {"success": False, "error": response.text}
-                return error_payload
-            result = response.json()
-            if result.get("success") and save_annotated and result.get("annotated_images"):
-                output_paths = save_annotated_images(
-                    result["annotated_images"],
-                    output_dir=self.output_dir,
-                )
-                result["output_paths"] = output_paths
-                result["output_path"] = output_paths[0] if output_paths else None
-            return result
+            out = response.json()
+            if response.status_code >= 400:
+                return {"success": False, "error": out.get("error", response.text)}
+            return out
         except Exception as e:
-            logger.error("Molmo2 infer request failed: %s", e)
+            logger.error("Molmo2 infer failed: %s", e)
             return {"success": False, "error": str(e)}
 
-    @staticmethod
-    def _encode_image(image_path: str) -> str:
-        mime = mimetypes.guess_type(image_path)[0] or "image/jpeg"
-        with open(image_path, "rb") as f:
-            encoded = base64.b64encode(f.read()).decode("utf-8")
-        return f"data:{mime};base64,{encoded}"
+    def infer_path(self, image_path: str, prompt: str = "Describe this image.", max_new_tokens: int = 200) -> Dict[str, Any]:
+        if not Path(image_path).exists():
+            return {"success": False, "error": f"Image file not found: {image_path}"}
+        return self.infer(image_path, prompt=prompt, max_new_tokens=max_new_tokens)

--- a/spagent/external_experts/Molmo2/molmo2_client.py
+++ b/spagent/external_experts/Molmo2/molmo2_client.py
@@ -1,0 +1,83 @@
+"""
+HTTP client for Molmo2 server.
+"""
+
+import base64
+import logging
+import mimetypes
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import requests
+
+from .point_utils import save_annotated_images
+
+logger = logging.getLogger(__name__)
+
+
+class Molmo2Client:
+    """Client for a Molmo2 inference server."""
+
+    def __init__(self, server_url: str = "http://localhost:20035", output_dir: Union[str, Path, None] = None):
+        self.server_url = server_url.rstrip("/")
+        self.output_dir = output_dir
+
+    def health_check(self) -> Dict:
+        try:
+            response = requests.get(f"{self.server_url}/health", timeout=10)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.error("Molmo2 health check failed: %s", e)
+            return {"success": False, "error": str(e)}
+
+    def infer(
+        self,
+        image_paths: List[str],
+        task: str,
+        prompt: str,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+        save_annotated: bool = True,
+    ) -> Dict:
+        try:
+            payload = {
+                "images": [self._encode_image(path) for path in image_paths],
+                "image_names": [Path(path).name for path in image_paths],
+                "task": task,
+                "prompt": prompt,
+                "max_new_tokens": max_new_tokens,
+                "temperature": temperature,
+                "save_annotated": save_annotated,
+            }
+            response = requests.post(
+                f"{self.server_url}/infer",
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=300,
+            )
+            if not response.ok:
+                try:
+                    error_payload = response.json()
+                except ValueError:
+                    error_payload = {"success": False, "error": response.text}
+                return error_payload
+            result = response.json()
+            if result.get("success") and save_annotated and result.get("annotated_images"):
+                output_paths = save_annotated_images(
+                    result["annotated_images"],
+                    output_dir=self.output_dir,
+                )
+                result["output_paths"] = output_paths
+                result["output_path"] = output_paths[0] if output_paths else None
+            return result
+        except Exception as e:
+            logger.error("Molmo2 infer request failed: %s", e)
+            return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def _encode_image(image_path: str) -> str:
+        mime = mimetypes.guess_type(image_path)[0] or "image/jpeg"
+        with open(image_path, "rb") as f:
+            encoded = base64.b64encode(f.read()).decode("utf-8")
+        return f"data:{mime};base64,{encoded}"

--- a/spagent/external_experts/Molmo2/molmo2_local.py
+++ b/spagent/external_experts/Molmo2/molmo2_local.py
@@ -1,0 +1,221 @@
+"""
+Local Molmo2 inference client built on top of Hugging Face Transformers.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class Molmo2LocalClient:
+    """Lazy-loading local Molmo2 client."""
+
+    def __init__(
+        self,
+        checkpoint: str = "allenai/Molmo2-4B",
+        device_map: str = "auto",
+        torch_dtype: str = "auto",
+    ):
+        self.checkpoint = checkpoint
+        self.device_map = device_map
+        self.torch_dtype = torch_dtype
+
+        self._torch = None
+        self._processor = None
+        self._model = None
+
+    def _ensure_model_loaded(self):
+        if self._model is not None and self._processor is not None:
+            return
+
+        try:
+            import torch
+            from transformers import AutoModelForImageTextToText, AutoProcessor
+        except ImportError as e:
+            raise ImportError(
+                "Molmo2 real mode requires transformers and torch. "
+                "If Molmo2 remote-code dependencies are missing, install the official project "
+                "from https://github.com/allenai/molmo2 or the ai2-molmo2 package."
+            ) from e
+
+        model_kwargs = {
+            "trust_remote_code": True,
+            "device_map": self.device_map,
+        }
+        if self.torch_dtype == "auto":
+            model_kwargs["torch_dtype"] = "auto"
+        else:
+            dtype = getattr(torch, self.torch_dtype, None)
+            if dtype is None:
+                raise ValueError(f"Unsupported torch dtype: {self.torch_dtype}")
+            model_kwargs["torch_dtype"] = dtype
+
+        self._processor = AutoProcessor.from_pretrained(
+            self.checkpoint,
+            trust_remote_code=True,
+            padding_side="left",
+        )
+        self._model = AutoModelForImageTextToText.from_pretrained(
+            self.checkpoint,
+            **model_kwargs,
+        )
+        self._torch = torch
+        logger.info("Loaded Molmo2 checkpoint: %s", self.checkpoint)
+
+    def _get_input_device(self):
+        if self._model is None:
+            raise RuntimeError("Molmo2 model is not loaded.")
+        try:
+            return next(self._model.parameters()).device
+        except StopIteration as e:
+            raise RuntimeError("Molmo2 model has no parameters.") from e
+
+    @staticmethod
+    def _load_images(image_paths: List[str]):
+        from PIL import Image
+
+        return [Image.open(path).convert("RGB") for path in image_paths]
+
+    def generate(
+        self,
+        image_paths: List[str],
+        prompt: str,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+    ) -> Dict:
+        self._ensure_model_loaded()
+
+        torch = self._torch
+        images = self._load_images(image_paths)
+        try:
+            messages = [{
+                "role": "user",
+                "content": [{"type": "text", "text": prompt}] + [
+                    {"type": "image", "image": image} for image in images
+                ],
+            }]
+
+            inputs = self._processor.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_tensors="pt",
+                return_dict=True,
+                padding=True,
+            )
+
+            input_device = self._get_input_device()
+            model_inputs = {
+                key: value.to(input_device) if hasattr(value, "to") else value
+                for key, value in inputs.items()
+            }
+
+            generation_kwargs = {
+                "max_new_tokens": max_new_tokens,
+                "do_sample": temperature > 0,
+            }
+            if temperature > 0:
+                generation_kwargs["temperature"] = temperature
+
+            with torch.inference_mode():
+                if input_device.type == "cuda":
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        output = self._model.generate(**model_inputs, **generation_kwargs)
+                else:
+                    output = self._model.generate(**model_inputs, **generation_kwargs)
+
+            generated_tokens = output[:, model_inputs["input_ids"].size(1):]
+            if hasattr(self._processor, "post_process_image_text_to_text"):
+                generated_text = self._processor.post_process_image_text_to_text(
+                    generated_tokens,
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=False,
+                )[0]
+            else:
+                generated_text = self._processor.decode(
+                    generated_tokens[0],
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=False,
+                )
+
+            return {
+                "success": True,
+                "generated_text": generated_text,
+                "prompt": prompt,
+                "image_paths": [str(Path(path)) for path in image_paths],
+            }
+        finally:
+            for image in images:
+                image.close()
+
+    def generate_from_images(
+        self,
+        images: List,
+        prompt: str,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+    ) -> Dict:
+        self._ensure_model_loaded()
+
+        torch = self._torch
+        try:
+            messages = [{
+                "role": "user",
+                "content": [{"type": "text", "text": prompt}] + [
+                    {"type": "image", "image": image} for image in images
+                ],
+            }]
+
+            inputs = self._processor.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_tensors="pt",
+                return_dict=True,
+                padding=True,
+            )
+
+            input_device = self._get_input_device()
+            model_inputs = {
+                key: value.to(input_device) if hasattr(value, "to") else value
+                for key, value in inputs.items()
+            }
+
+            generation_kwargs = {
+                "max_new_tokens": max_new_tokens,
+                "do_sample": temperature > 0,
+            }
+            if temperature > 0:
+                generation_kwargs["temperature"] = temperature
+
+            with torch.inference_mode():
+                if input_device.type == "cuda":
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        output = self._model.generate(**model_inputs, **generation_kwargs)
+                else:
+                    output = self._model.generate(**model_inputs, **generation_kwargs)
+
+            generated_tokens = output[:, model_inputs["input_ids"].size(1):]
+            if hasattr(self._processor, "post_process_image_text_to_text"):
+                generated_text = self._processor.post_process_image_text_to_text(
+                    generated_tokens,
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=False,
+                )[0]
+            else:
+                generated_text = self._processor.decode(
+                    generated_tokens[0],
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=False,
+                )
+
+            return {
+                "success": True,
+                "generated_text": generated_text,
+                "prompt": prompt,
+            }
+        except Exception as e:
+            logger.error("Molmo2 generate_from_images failed: %s", e)
+            return {"success": False, "error": str(e)}

--- a/spagent/external_experts/Molmo2/molmo2_server.py
+++ b/spagent/external_experts/Molmo2/molmo2_server.py
@@ -1,0 +1,123 @@
+"""
+Flask server for Molmo2 local inference.
+"""
+
+import argparse
+import base64
+import io
+import logging
+import mimetypes
+from typing import List
+
+from flask import Flask, jsonify, request
+from PIL import Image
+
+from .molmo2_local import Molmo2LocalClient
+from .point_utils import annotate_images_as_base64, extract_points_from_text, group_points_by_image
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+_client: Molmo2LocalClient = None
+
+
+def _decode_image(data_url: str) -> Image.Image:
+    if "," in data_url:
+        _, encoded = data_url.split(",", 1)
+    else:
+        encoded = data_url
+    image_bytes = base64.b64decode(encoded)
+    return Image.open(io.BytesIO(image_bytes)).convert("RGB")
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({
+        "success": True,
+        "status": "ok",
+        "model_loaded": _client is not None,
+        "checkpoint": getattr(_client, "checkpoint", None),
+    })
+
+
+@app.route("/test", methods=["GET"])
+def test():
+    return jsonify({"success": True, "message": "Molmo2 server is reachable"})
+
+
+@app.route("/infer", methods=["POST"])
+def infer():
+    images = []
+    try:
+        data = request.get_json(force=True)
+        images_data: List[str] = data.get("images", [])
+        image_names: List[str] = data.get("image_names", [])
+        task = data.get("task", "qa")
+        prompt = data.get("prompt", "")
+        max_new_tokens = int(data.get("max_new_tokens", 256))
+        temperature = float(data.get("temperature", 0.0))
+        save_annotated = bool(data.get("save_annotated", True))
+
+        if not images_data:
+            return jsonify({"success": False, "error": "No images provided"}), 400
+
+        images = [_decode_image(item) for item in images_data]
+        if not image_names:
+            ext = mimetypes.guess_extension("image/jpeg") or ".jpg"
+            image_names = [f"image_{idx+1}{ext}" for idx in range(len(images))]
+
+        result = _client.generate_from_images(
+            images=images,
+            prompt=prompt,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+        )
+        if not result.get("success"):
+            return jsonify(result), 500
+
+        response = {
+            "success": True,
+            "generated_text": result.get("generated_text", "").strip(),
+            "task": task,
+            "image_names": image_names,
+        }
+
+        if task == "point":
+            image_sizes = [image.size for image in images]
+            fake_paths = image_names
+            points = extract_points_from_text(response["generated_text"], image_sizes)
+            grouped_points = group_points_by_image(points, fake_paths)
+            response["points_by_image"] = grouped_points
+            response["num_points"] = sum(len(group["points"]) for group in grouped_points)
+            if save_annotated:
+                response["annotated_images"] = annotate_images_as_base64(images, grouped_points)
+        return jsonify(response)
+    except Exception as e:
+        logger.exception("Molmo2 inference failed")
+        return jsonify({"success": False, "error": str(e)}), 500
+    finally:
+        for image in images:
+            image.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Molmo2 inference server")
+    parser.add_argument("--checkpoint", default="allenai/Molmo2-4B")
+    parser.add_argument("--device_map", default="auto")
+    parser.add_argument("--torch_dtype", default="auto")
+    parser.add_argument("--port", type=int, default=20035)
+    args = parser.parse_args()
+
+    global _client
+    _client = Molmo2LocalClient(
+        checkpoint=args.checkpoint,
+        device_map=args.device_map,
+        torch_dtype=args.torch_dtype,
+    )
+    logger.info("Starting Molmo2 server on port %s", args.port)
+    app.run(host="0.0.0.0", port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/spagent/external_experts/Molmo2/molmo2_server.py
+++ b/spagent/external_experts/Molmo2/molmo2_server.py
@@ -1,122 +1,247 @@
 """
-Flask server for Molmo2 local inference.
+Molmo2 HTTP service using Hugging Face Transformers checkpoints.
+
+Environment:
+  MOLMO2_MODEL   HF repo id or local directory (default: allenai/Molmo2-4B)
+  HF_HOME        Hugging Face cache location (optional)
+
+Optional video input uses the same message schema as allenai/molmo2 (URL or path string).
+
+Install: `transformers` 4.57+ and `<5` (v5 `ProcessorMixin` rejects Molmo2 optional kwargs), `accelerate`, `torch`.
+Video decoding may require `torchcodec` per upstream molmo2 docs.
 """
+
+from __future__ import annotations
 
 import argparse
 import base64
 import io
 import logging
-import mimetypes
-from typing import List
+import os
+import traceback
+from typing import Any, Dict, List, Optional
 
 from flask import Flask, jsonify, request
 from PIL import Image
 
-from .molmo2_local import Molmo2LocalClient
-from .point_utils import annotate_images_as_base64, extract_points_from_text, group_points_by_image
-
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
-_client: Molmo2LocalClient = None
+
+_model = None
+_processor = None
+_device: Optional[str] = None
 
 
-def _decode_image(data_url: str) -> Image.Image:
-    if "," in data_url:
-        _, encoded = data_url.split(",", 1)
+def _load_hf():
+    global _model, _processor, _device
+    import torch
+    from transformers import AutoModelForImageTextToText, AutoProcessor
+
+    checkpoint_dir = os.environ.get("MOLMO2_MODEL", "allenai/Molmo2-4B")
+    logger.info("Loading Molmo2 from %s", checkpoint_dir)
+
+    common_kw = {"trust_remote_code": True}
+    proc_kw = {**common_kw, "padding_side": "left"}
+
+    _processor = AutoProcessor.from_pretrained(checkpoint_dir, **proc_kw)
+
+    if torch.cuda.is_available():
+        try:
+            _model = AutoModelForImageTextToText.from_pretrained(
+                checkpoint_dir,
+                **common_kw,
+                dtype="auto",
+                device_map="auto",
+            )
+        except TypeError:
+            _model = AutoModelForImageTextToText.from_pretrained(
+                checkpoint_dir,
+                **common_kw,
+                torch_dtype=torch.bfloat16,
+                device_map="auto",
+            )
+        _device = "cuda"
     else:
-        encoded = data_url
-    image_bytes = base64.b64decode(encoded)
-    return Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        logger.warning("CUDA not available; loading on CPU (slow).")
+        try:
+            _model = AutoModelForImageTextToText.from_pretrained(
+                checkpoint_dir, **common_kw, dtype="auto"
+            )
+        except TypeError:
+            _model = AutoModelForImageTextToText.from_pretrained(
+                checkpoint_dir, **common_kw, torch_dtype=torch.float32
+            )
+        _model = _model.to("cpu")
+        _device = "cpu"
+
+    _model.eval()
+    logger.info("Molmo2 loaded.")
+    return True
+
+
+def load_model() -> bool:
+    try:
+        _load_hf()
+        return True
+    except Exception as e:
+        logger.error("Failed to load Molmo2: %s", e)
+        logger.error(traceback.format_exc())
+        return False
+
+
+def _model_device(torch_module) -> "torch.device":
+    import torch
+
+    try:
+        return next(torch_module.parameters()).device
+    except StopIteration:
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _generate_from_messages(messages: List[Dict[str, Any]], max_new_tokens: int) -> str:
+    import torch
+
+    assert _processor is not None and _model is not None
+
+    inputs = _processor.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        return_tensors="pt",
+        return_dict=True,
+        padding=True,
+    )
+    dev = _model_device(_model)
+    inputs = {k: v.to(dev) if hasattr(v, "to") else v for k, v in inputs.items()}
+
+    use_cuda = dev.type == "cuda"
+    with torch.inference_mode():
+        if use_cuda:
+            with torch.autocast("cuda", dtype=torch.bfloat16):
+                output = _model.generate(**inputs, max_new_tokens=max_new_tokens)
+        else:
+            output = _model.generate(**inputs, max_new_tokens=max_new_tokens)
+
+    generated_tokens = output[0, inputs["input_ids"].size(1) :]
+    return _processor.decode(generated_tokens, skip_special_tokens=True)
 
 
 @app.route("/health", methods=["GET"])
 def health():
-    return jsonify({
-        "success": True,
-        "status": "ok",
-        "model_loaded": _client is not None,
-        "checkpoint": getattr(_client, "checkpoint", None),
-    })
+    return jsonify(
+        {
+            "status": "ok",
+            "model_loaded": _model is not None,
+            "checkpoint": os.environ.get("MOLMO2_MODEL", "allenai/Molmo2-4B"),
+            "device": _device,
+        }
+    )
 
 
 @app.route("/test", methods=["GET"])
 def test():
-    return jsonify({"success": True, "message": "Molmo2 server is reachable"})
+    if _model is None:
+        return jsonify({"success": False, "error": "Model not loaded"}), 500
+    try:
+        img = Image.new("RGB", (128, 128), color=(120, 80, 200))
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Reply with exactly: ok"},
+                    {"type": "image", "image": img},
+                ],
+            }
+        ]
+        text = _generate_from_messages(messages, max_new_tokens=16)
+        return jsonify({"success": True, "sample_output": text.strip()})
+    except Exception as e:
+        logger.error("Test inference failed: %s", e)
+        logger.error(traceback.format_exc())
+        return jsonify({"success": False, "error": str(e)}), 500
 
 
 @app.route("/infer", methods=["POST"])
 def infer():
-    images = []
+    if _model is None:
+        return jsonify({"success": False, "error": "Model not loaded"}), 500
+
+    data = request.get_json(silent=True) or {}
+    prompt = data.get("prompt") or "Describe this image."
+    max_new_tokens = int(data.get("max_new_tokens", 200))
+
     try:
-        data = request.get_json(force=True)
-        images_data: List[str] = data.get("images", [])
-        image_names: List[str] = data.get("image_names", [])
-        task = data.get("task", "qa")
-        prompt = data.get("prompt", "")
-        max_new_tokens = int(data.get("max_new_tokens", 256))
-        temperature = float(data.get("temperature", 0.0))
-        save_annotated = bool(data.get("save_annotated", True))
+        if "video" in data and data["video"]:
+            video_ref = data["video"]
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {"type": "video", "video": video_ref},
+                    ],
+                }
+            ]
+            text = _generate_from_messages(messages, max_new_tokens=max_new_tokens)
+            return jsonify(
+                {
+                    "success": True,
+                    "text": text.strip(),
+                    "checkpoint": os.environ.get("MOLMO2_MODEL", "allenai/Molmo2-4B"),
+                }
+            )
 
-        if not images_data:
-            return jsonify({"success": False, "error": "No images provided"}), 400
+        if "image" not in data:
+            return jsonify({"success": False, "error": "Missing 'image' (base64) or 'video' (url/path)"}), 400
 
-        images = [_decode_image(item) for item in images_data]
-        if not image_names:
-            ext = mimetypes.guess_extension("image/jpeg") or ".jpg"
-            image_names = [f"image_{idx+1}{ext}" for idx in range(len(images))]
-
-        result = _client.generate_from_images(
-            images=images,
-            prompt=prompt,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
+        raw = base64.b64decode(data["image"])
+        image = Image.open(io.BytesIO(raw)).convert("RGB")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image", "image": image},
+                ],
+            }
+        ]
+        text = _generate_from_messages(messages, max_new_tokens=max_new_tokens)
+        return jsonify(
+            {
+                "success": True,
+                "text": text.strip(),
+                "checkpoint": os.environ.get("MOLMO2_MODEL", "allenai/Molmo2-4B"),
+            }
         )
-        if not result.get("success"):
-            return jsonify(result), 500
-
-        response = {
-            "success": True,
-            "generated_text": result.get("generated_text", "").strip(),
-            "task": task,
-            "image_names": image_names,
-        }
-
-        if task == "point":
-            image_sizes = [image.size for image in images]
-            fake_paths = image_names
-            points = extract_points_from_text(response["generated_text"], image_sizes)
-            grouped_points = group_points_by_image(points, fake_paths)
-            response["points_by_image"] = grouped_points
-            response["num_points"] = sum(len(group["points"]) for group in grouped_points)
-            if save_annotated:
-                response["annotated_images"] = annotate_images_as_base64(images, grouped_points)
-        return jsonify(response)
     except Exception as e:
-        logger.exception("Molmo2 inference failed")
+        logger.error("Infer failed: %s", e)
+        logger.error(traceback.format_exc())
         return jsonify({"success": False, "error": str(e)}), 500
-    finally:
-        for image in images:
-            image.close()
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Molmo2 inference server")
-    parser.add_argument("--checkpoint", default="allenai/Molmo2-4B")
-    parser.add_argument("--device_map", default="auto")
-    parser.add_argument("--torch_dtype", default="auto")
-    parser.add_argument("--port", type=int, default=20035)
-    args = parser.parse_args()
-
-    global _client
-    _client = Molmo2LocalClient(
-        checkpoint=args.checkpoint,
-        device_map=args.device_map,
-        torch_dtype=args.torch_dtype,
+    parser = argparse.ArgumentParser(description="Molmo2 Flask server")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=20025)
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Override MOLMO2_MODEL (HF id or local directory).",
     )
-    logger.info("Starting Molmo2 server on port %s", args.port)
-    app.run(host="0.0.0.0", port=args.port)
+    args = parser.parse_args()
+    if args.model:
+        os.environ["MOLMO2_MODEL"] = args.model
+
+    if not load_model():
+        logger.error("Aborting: model load failed.")
+        raise SystemExit(1)
+
+    app.run(host=args.host, port=args.port, threaded=False)
 
 
 if __name__ == "__main__":

--- a/spagent/external_experts/Molmo2/point_utils.py
+++ b/spagent/external_experts/Molmo2/point_utils.py
@@ -1,0 +1,160 @@
+"""
+Point parsing and annotation helpers for Molmo2 integration.
+"""
+
+import base64
+import io
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Union
+
+from PIL import Image, ImageDraw
+
+_UNIFIED_COORD_RE = re.compile(r'<(?:points|tracks).*?coords="([0-9\t:;, .]+)"\s*/?>')
+_UNIFIED_FRAME_RE = re.compile(r'(?:^|\t|:|,|;)([0-9\.]+) ([0-9\. ]+)')
+_UNIFIED_POINT_RE = re.compile(r'([0-9]+) ([0-9]{3,4}) ([0-9]{3,4})')
+_LEGACY_POINT_PATTERNS = [
+    re.compile(r"Click\(([0-9]+\.[0-9]), ?([0-9]+\.[0-9])\)"),
+    re.compile(r"\(([0-9]+\.[0-9]),? ?([0-9]+\.[0-9])\)"),
+    re.compile(r'x\d*="\s*([0-9]+(?:\.[0-9]+)?)"\s+y\d*="\s*([0-9]+(?:\.[0-9]+)?)"'),
+]
+
+
+def default_output_dir() -> Path:
+    return Path(tempfile.gettempdir()) / "spagent_molmo2"
+
+
+def extract_points_from_text(
+    text: str,
+    image_sizes: List[Tuple[int, int]],
+) -> List[Tuple[int, float, float]]:
+    if len(image_sizes) == 1:
+        width, height = image_sizes[0]
+        points = _extract_unified_points(text, width, height)
+        if points:
+            return points
+        return _extract_legacy_points(text, width, height)
+
+    widths = [size[0] for size in image_sizes]
+    heights = [size[1] for size in image_sizes]
+    return _extract_unified_points(text, widths, heights)
+
+
+def group_points_by_image(
+    points: List[Tuple[int, float, float]],
+    image_paths: List[str],
+) -> List[Dict[str, Any]]:
+    grouped: List[Dict[str, Any]] = []
+    for image_index, image_path in enumerate(image_paths, start=1):
+        image_points = [
+            {"x": round(x, 2), "y": round(y, 2)}
+            for frame_id, x, y in points
+            if frame_id == image_index
+        ]
+        grouped.append({
+            "image_index": image_index,
+            "image_path": image_path,
+            "points": image_points,
+        })
+    return grouped
+
+
+def annotate_images_as_base64(
+    image_sources: List[Union[str, Image.Image]],
+    grouped_points: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    annotated_images: List[Dict[str, Any]] = []
+    for group in grouped_points:
+        if not group["points"]:
+            continue
+
+        image_index = group["image_index"]
+        image_path = group["image_path"]
+        image_source = image_sources[image_index - 1]
+
+        if isinstance(image_source, Image.Image):
+            image = image_source.convert("RGB").copy()
+        else:
+            with Image.open(image_source) as loaded_image:
+                image = loaded_image.convert("RGB")
+
+        draw = ImageDraw.Draw(image)
+        radius = max(4, int(max(image.size) * 0.01))
+        for point_index, point in enumerate(group["points"], start=1):
+            x = point["x"]
+            y = point["y"]
+            draw.ellipse(
+                (x - radius, y - radius, x + radius, y + radius),
+                fill="rgb(240, 82, 156)",
+            )
+            draw.text((x + radius + 2, y - radius), str(point_index), fill="white")
+
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG")
+        annotated_images.append({
+            "image_index": image_index,
+            "image_path": image_path,
+            "image_base64": base64.b64encode(buffer.getvalue()).decode("utf-8"),
+        })
+    return annotated_images
+
+
+def save_annotated_images(
+    annotated_images: List[Dict[str, Any]],
+    output_dir: Union[str, Path, None] = None,
+) -> List[str]:
+    base_dir = Path(output_dir) if output_dir else default_output_dir()
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    saved_paths: List[str] = []
+    for item in annotated_images:
+        image_path = item["image_path"]
+        image_index = item["image_index"]
+        stem = Path(image_path).stem
+        suffix = f"_img{image_index}" if len(annotated_images) > 1 else ""
+        output_path = base_dir / f"{stem}{suffix}_molmo2_point.jpg"
+        with open(output_path, "wb") as f:
+            f.write(base64.b64decode(item["image_base64"]))
+        saved_paths.append(str(output_path))
+    return saved_paths
+
+
+def _extract_unified_points(
+    text: str,
+    widths: Union[int, List[int]],
+    heights: Union[int, List[int]],
+) -> List[Tuple[int, float, float]]:
+    all_points: List[Tuple[int, float, float]] = []
+    multi_image = isinstance(widths, (list, tuple)) and isinstance(heights, (list, tuple))
+
+    for coord_match in _UNIFIED_COORD_RE.finditer(text):
+        for frame_match in _UNIFIED_FRAME_RE.finditer(coord_match.group(1)):
+            frame_id = int(float(frame_match.group(1))) if multi_image else 1
+            if multi_image:
+                if frame_id < 1 or frame_id > len(widths):
+                    continue
+                width = widths[frame_id - 1]
+                height = heights[frame_id - 1]
+            else:
+                width = widths
+                height = heights
+
+            for point_match in _UNIFIED_POINT_RE.finditer(frame_match.group(2)):
+                x = float(point_match.group(2)) / 1000.0 * width
+                y = float(point_match.group(3)) / 1000.0 * height
+                if 0 <= x <= width and 0 <= y <= height:
+                    all_points.append((frame_id, x, y))
+    return all_points
+
+
+def _extract_legacy_points(text: str, width: int, height: int) -> List[Tuple[int, float, float]]:
+    all_points: List[Tuple[int, float, float]] = []
+    for pattern in _LEGACY_POINT_PATTERNS:
+        for match in pattern.finditer(text):
+            x = float(match.group(1))
+            y = float(match.group(2))
+            if max(x, y) > 100:
+                continue
+            all_points.append((1, x / 100.0 * width, y / 100.0 * height))
+    return all_points

--- a/spagent/tools/__init__.py
+++ b/spagent/tools/__init__.py
@@ -12,6 +12,7 @@ from .supervision_tool import SupervisionTool
 from .yoloe_tool import YOLOETool
 from .yolo26_tool import YOLO26Tool
 from .moondream_tool import MoondreamTool
+from .molmo2_tool import Molmo2Tool
 from .pi3_tool import Pi3Tool
 from .pi3x_tool import Pi3XTool
 from .vggt_tool import VGGTTool
@@ -31,6 +32,7 @@ __all__ = [
     'YOLOETool',
     'YOLO26Tool',
     'MoondreamTool',
+    'Molmo2Tool',
     'Pi3Tool',
     'Pi3XTool',
     'VGGTTool',

--- a/spagent/tools/molmo2_tool.py
+++ b/spagent/tools/molmo2_tool.py
@@ -1,11 +1,9 @@
 """
-Molmo2 Tool
-
-SPAgent wrapper for Molmo2 visual reasoning and pointing.
+Molmo2 Tool — vision-language inference via the Molmo2 HTTP expert (or mock).
 """
 
-import sys
 import logging
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -15,48 +13,110 @@ from core.tool import Tool
 
 logger = logging.getLogger(__name__)
 
-def _normalize_image_paths(image_path: Union[str, List[str]]) -> List[str]:
-    if isinstance(image_path, str):
-        return [image_path]
-    if isinstance(image_path, (list, tuple)):
-        return [str(path) for path in image_path]
-    raise TypeError(f"Unsupported image_path type: {type(image_path)}")
-
 
 class Molmo2Tool(Tool):
-    """Tool for Molmo2 reasoning and point-driven grounding."""
+    """Vision-language tasks (qa, caption, point) using a Molmo2 Transformers server."""
 
     def __init__(
         self,
         use_mock: bool = True,
-        server_url: str = "http://localhost:20035",
+        server_url: str = "http://localhost:20025",
         output_dir: Optional[str] = None,
     ):
         super().__init__(
             name="molmo2_tool",
             description=(
-                "Run Molmo2 multimodal reasoning on one or more images. "
-                "Use this for visual question answering, captioning, multi-image comparison, "
-                "or point grounding when you want Molmo2 to point to an object or region."
-            )
+                "Molmo2: image QA, captioning, or pointing (point parses model output and can save overlays). "
+                "Requires Molmo2 server unless use_mock=True."
+            ),
         )
         self.use_mock = use_mock
         self.server_url = server_url
-        self.output_dir = str(output_dir) if output_dir is not None else None
+        self.output_dir = output_dir
         self._client = None
         self._init_client()
 
-    def _init_client(self):
+    def _init_client(self) -> None:
         if self.use_mock:
-            from external_experts.Molmo2.mock_molmo2_service import MockMolmo2Service
-
-            self._client = MockMolmo2Service(output_dir=self.output_dir)
-            logger.info("Using mock Molmo2 service")
-        else:
+            self._client = None
+            logger.info("Using mock Molmo2 (no HTTP)")
+            return
+        try:
             from external_experts.Molmo2.molmo2_client import Molmo2Client
 
-            self._client = Molmo2Client(server_url=self.server_url, output_dir=self.output_dir)
-            logger.info("Using real Molmo2 service at %s", self.server_url)
+            self._client = Molmo2Client(server_url=self.server_url)
+            logger.info("Using Molmo2 service at %s", self.server_url)
+        except ImportError as e:
+            logger.error("Failed to import Molmo2 client: %s", e)
+            raise
+
+    @staticmethod
+    def _normalize_paths(image_path: Union[str, List[str]]) -> List[str]:
+        if isinstance(image_path, (list, tuple)):
+            return [str(Path(p)) for p in image_path]
+        return [str(Path(image_path))]
+
+    def _generate_text(self, primary_path: str, prompt: str, max_new_tokens: int) -> Dict[str, Any]:
+        if self.use_mock:
+            return {
+                "success": True,
+                "text": f"[mock] {prompt[:120]} on {Path(primary_path).name}",
+            }
+        assert self._client is not None
+        return self._client.infer_path(primary_path, prompt=prompt, max_new_tokens=max_new_tokens)
+
+    def _run_point(
+        self,
+        paths: List[str],
+        prompt: str,
+        save_annotated: bool,
+        max_new_tokens: int,
+        out_base: Optional[Path],
+    ) -> Dict[str, Any]:
+        from PIL import Image
+
+        from external_experts.Molmo2.point_utils import (
+            annotate_images_as_base64,
+            default_output_dir,
+            extract_points_from_text,
+            group_points_by_image,
+            save_annotated_images,
+        )
+
+        if self.use_mock:
+            # Legacy point regex requires decimals, e.g. Click(50.0, 50.0)
+            raw_text = "Click(50.0, 50.0)"
+        else:
+            gen = self._generate_text(paths[0], prompt, max_new_tokens)
+            if not gen.get("success"):
+                return {"success": False, "error": gen.get("error", "generation failed")}
+            raw_text = gen.get("text", "")
+        sizes: List[tuple] = []
+        for p in paths:
+            with Image.open(p) as im:
+                sizes.append(im.size)
+        points = extract_points_from_text(raw_text, sizes)
+        grouped = group_points_by_image(points, paths)
+
+        result: Dict[str, Any] = {
+            "task": "point",
+            "raw_text": raw_text,
+            "num_points": len(points),
+            "points_by_image": grouped,
+        }
+
+        output_path: Optional[str] = None
+        if save_annotated and points:
+            annotated = annotate_images_as_base64(paths, grouped)
+            dest = out_base if out_base is not None else default_output_dir()
+            saved = save_annotated_images(annotated, output_dir=dest)
+            if saved:
+                output_path = saved[0]
+            result["saved_paths"] = saved
+        elif save_annotated and not points:
+            logger.warning("point task: no parseable points in model output")
+
+        return {"success": True, "result": result, "output_path": output_path, "response_text": raw_text[:500]}
 
     @property
     def parameters(self) -> Dict[str, Any]:
@@ -64,66 +124,24 @@ class Molmo2Tool(Tool):
             "type": "object",
             "properties": {
                 "image_path": {
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "description": "Path to a single input image.",
-                        },
-                        {
-                            "type": "array",
-                            "description": "List of input image paths for multi-image reasoning.",
-                            "items": {"type": "string"},
-                            "minItems": 1,
-                        },
-                    ],
-                    "description": "Path to one image or a list of image paths.",
+                    "type": "string",
+                    "description": "Path to the input image (or use list in code for multi-image).",
                 },
                 "task": {
                     "type": "string",
                     "enum": ["qa", "caption", "point"],
-                    "description": (
-                        "qa: answer a visual question or compare images; "
-                        "caption: describe the image(s); "
-                        "point: point to an object or region and optionally save annotated image(s)."
-                    ),
-                    "default": "qa",
+                    "description": "qa: answer a question; caption: describe; point: grounding (parses coords).",
                 },
-                "prompt": {
-                    "type": "string",
-                    "description": (
-                        "Instruction or question for Molmo2. Required for qa and point. "
-                        "Optional for caption."
-                    ),
-                },
+                "prompt": {"type": "string", "description": "Question, caption hint, or pointing instruction."},
                 "save_annotated": {
                     "type": "boolean",
-                    "description": "When task=point, save annotated image(s) with the predicted points.",
+                    "description": "For task=point, save JPEG overlay(s) with marked points.",
                     "default": True,
                 },
-                "max_new_tokens": {
-                    "type": "integer",
-                    "description": "Maximum number of tokens to generate.",
-                    "default": 256,
-                    "minimum": 1,
-                    "maximum": 2048,
-                },
-                "temperature": {
-                    "type": "number",
-                    "description": "Sampling temperature for generation. Use 0 for deterministic outputs.",
-                    "default": 0.0,
-                    "minimum": 0.0,
-                    "maximum": 2.0,
-                },
+                "max_new_tokens": {"type": "integer", "default": 200},
             },
-            "required": ["image_path", "task"],
+            "required": ["image_path"],
         }
-
-    def _default_prompt(self, task: str, image_count: int) -> str:
-        if task == "caption":
-            if image_count == 1:
-                return "Describe this image in detail."
-            return "Describe these images and compare their main similarities and differences."
-        raise ValueError(f"Prompt is required for task '{task}'.")
 
     def call(
         self,
@@ -131,67 +149,50 @@ class Molmo2Tool(Tool):
         task: str = "qa",
         prompt: Optional[str] = None,
         save_annotated: bool = True,
-        max_new_tokens: int = 256,
-        temperature: float = 0.0,
+        max_new_tokens: int = 200,
     ) -> Dict[str, Any]:
-        try:
-            image_paths = _normalize_image_paths(image_path)
-            for path in image_paths:
-                if not Path(path).exists():
-                    return {"success": False, "error": f"Image file not found: {path}"}
+        paths = self._normalize_paths(image_path)
+        for p in paths:
+            if not Path(p).exists():
+                return {"success": False, "error": f"Image file not found: {p}"}
 
-            if task not in {"qa", "caption", "point"}:
+        out_base = Path(self.output_dir) if self.output_dir else None
+
+        try:
+            if task == "caption":
+                use_prompt = prompt or "Describe this image."
+                eff_task = "caption"
+            elif task == "qa":
+                use_prompt = prompt or "What do you see in this image? Answer briefly."
+                eff_task = "qa"
+            elif task == "point":
+                use_prompt = prompt or (
+                    "Point to the requested location. Output pointing coordinates in the model's standard format."
+                )
+                return self._run_point(paths, use_prompt, save_annotated, max_new_tokens, out_base)
+            else:
                 return {"success": False, "error": f"Unknown task: {task}"}
 
-            effective_prompt = prompt.strip() if prompt and prompt.strip() else self._default_prompt(task, len(image_paths))
-            logger.info("Running Molmo2 task=%s on %d image(s)", task, len(image_paths))
+            if self.use_mock:
+                gen_text = f"[mock] {use_prompt[:120]} on {Path(paths[0]).name}"
+                return {
+                    "success": True,
+                    "result": {"task": eff_task, "generated_text": gen_text, "prompt": use_prompt},
+                    "response_text": gen_text,
+                }
 
-            result = self._client.infer(
-                image_paths=image_paths,
-                task=task,
-                prompt=effective_prompt,
-                max_new_tokens=max_new_tokens,
-                temperature=temperature,
-                save_annotated=save_annotated,
-            )
-            if not result or not result.get("success"):
-                error_msg = result.get("error", "Unknown error") if result else "No result returned"
-                return {"success": False, "error": f"Molmo2 inference failed: {error_msg}"}
+            assert self._client is not None
+            remote = self._client.infer_path(paths[0], prompt=use_prompt, max_new_tokens=max_new_tokens)
+            if not remote.get("success"):
+                return {"success": False, "error": remote.get("error", "Unknown error")}
 
-            generated_text = result.get("generated_text", "").strip()
-            result_payload: Dict[str, Any] = {
-                "task": task,
-                "prompt": effective_prompt,
-                "image_paths": image_paths,
-                "generated_text": generated_text,
-            }
-
-            if task == "point":
-                result_payload["points_by_image"] = result.get("points_by_image", [])
-                result_payload["num_points"] = result.get("num_points", 0)
-
-            response: Dict[str, Any] = {
+            gen_text = remote.get("text", "")
+            return {
                 "success": True,
-                "result": result_payload,
-                "response_text": generated_text,
-                "output_path": result.get("output_path"),
-                "output_paths": result.get("output_paths", []),
+                "result": {"task": eff_task, "generated_text": gen_text, "prompt": use_prompt},
+                "response_text": gen_text,
+                "raw": remote,
             }
-
-            if task == "point":
-                response["description"] = (
-                    f"Molmo2 point grounding completed on {len(image_paths)} image(s), "
-                    f"returning {response['result']['num_points']} point(s)."
-                )
-                response["summary"] = response["description"]
-            else:
-                response["summary"] = generated_text[:240]
-                response["description"] = (
-                    f"Molmo2 {task} completed on {len(image_paths)} image(s). "
-                    f"Generated response: {generated_text[:180]}"
-                )
-
-            return response
         except Exception as e:
-            logger.error("Molmo2Tool error: %s", e)
+            logger.exception("Molmo2 tool error")
             return {"success": False, "error": str(e)}

--- a/spagent/tools/molmo2_tool.py
+++ b/spagent/tools/molmo2_tool.py
@@ -1,0 +1,197 @@
+"""
+Molmo2 Tool
+
+SPAgent wrapper for Molmo2 visual reasoning and pointing.
+"""
+
+import sys
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from core.tool import Tool
+
+logger = logging.getLogger(__name__)
+
+def _normalize_image_paths(image_path: Union[str, List[str]]) -> List[str]:
+    if isinstance(image_path, str):
+        return [image_path]
+    if isinstance(image_path, (list, tuple)):
+        return [str(path) for path in image_path]
+    raise TypeError(f"Unsupported image_path type: {type(image_path)}")
+
+
+class Molmo2Tool(Tool):
+    """Tool for Molmo2 reasoning and point-driven grounding."""
+
+    def __init__(
+        self,
+        use_mock: bool = True,
+        server_url: str = "http://localhost:20035",
+        output_dir: Optional[str] = None,
+    ):
+        super().__init__(
+            name="molmo2_tool",
+            description=(
+                "Run Molmo2 multimodal reasoning on one or more images. "
+                "Use this for visual question answering, captioning, multi-image comparison, "
+                "or point grounding when you want Molmo2 to point to an object or region."
+            )
+        )
+        self.use_mock = use_mock
+        self.server_url = server_url
+        self.output_dir = str(output_dir) if output_dir is not None else None
+        self._client = None
+        self._init_client()
+
+    def _init_client(self):
+        if self.use_mock:
+            from external_experts.Molmo2.mock_molmo2_service import MockMolmo2Service
+
+            self._client = MockMolmo2Service(output_dir=self.output_dir)
+            logger.info("Using mock Molmo2 service")
+        else:
+            from external_experts.Molmo2.molmo2_client import Molmo2Client
+
+            self._client = Molmo2Client(server_url=self.server_url, output_dir=self.output_dir)
+            logger.info("Using real Molmo2 service at %s", self.server_url)
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "image_path": {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "description": "Path to a single input image.",
+                        },
+                        {
+                            "type": "array",
+                            "description": "List of input image paths for multi-image reasoning.",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                        },
+                    ],
+                    "description": "Path to one image or a list of image paths.",
+                },
+                "task": {
+                    "type": "string",
+                    "enum": ["qa", "caption", "point"],
+                    "description": (
+                        "qa: answer a visual question or compare images; "
+                        "caption: describe the image(s); "
+                        "point: point to an object or region and optionally save annotated image(s)."
+                    ),
+                    "default": "qa",
+                },
+                "prompt": {
+                    "type": "string",
+                    "description": (
+                        "Instruction or question for Molmo2. Required for qa and point. "
+                        "Optional for caption."
+                    ),
+                },
+                "save_annotated": {
+                    "type": "boolean",
+                    "description": "When task=point, save annotated image(s) with the predicted points.",
+                    "default": True,
+                },
+                "max_new_tokens": {
+                    "type": "integer",
+                    "description": "Maximum number of tokens to generate.",
+                    "default": 256,
+                    "minimum": 1,
+                    "maximum": 2048,
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Sampling temperature for generation. Use 0 for deterministic outputs.",
+                    "default": 0.0,
+                    "minimum": 0.0,
+                    "maximum": 2.0,
+                },
+            },
+            "required": ["image_path", "task"],
+        }
+
+    def _default_prompt(self, task: str, image_count: int) -> str:
+        if task == "caption":
+            if image_count == 1:
+                return "Describe this image in detail."
+            return "Describe these images and compare their main similarities and differences."
+        raise ValueError(f"Prompt is required for task '{task}'.")
+
+    def call(
+        self,
+        image_path: Union[str, List[str]],
+        task: str = "qa",
+        prompt: Optional[str] = None,
+        save_annotated: bool = True,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+    ) -> Dict[str, Any]:
+        try:
+            image_paths = _normalize_image_paths(image_path)
+            for path in image_paths:
+                if not Path(path).exists():
+                    return {"success": False, "error": f"Image file not found: {path}"}
+
+            if task not in {"qa", "caption", "point"}:
+                return {"success": False, "error": f"Unknown task: {task}"}
+
+            effective_prompt = prompt.strip() if prompt and prompt.strip() else self._default_prompt(task, len(image_paths))
+            logger.info("Running Molmo2 task=%s on %d image(s)", task, len(image_paths))
+
+            result = self._client.infer(
+                image_paths=image_paths,
+                task=task,
+                prompt=effective_prompt,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                save_annotated=save_annotated,
+            )
+            if not result or not result.get("success"):
+                error_msg = result.get("error", "Unknown error") if result else "No result returned"
+                return {"success": False, "error": f"Molmo2 inference failed: {error_msg}"}
+
+            generated_text = result.get("generated_text", "").strip()
+            result_payload: Dict[str, Any] = {
+                "task": task,
+                "prompt": effective_prompt,
+                "image_paths": image_paths,
+                "generated_text": generated_text,
+            }
+
+            if task == "point":
+                result_payload["points_by_image"] = result.get("points_by_image", [])
+                result_payload["num_points"] = result.get("num_points", 0)
+
+            response: Dict[str, Any] = {
+                "success": True,
+                "result": result_payload,
+                "response_text": generated_text,
+                "output_path": result.get("output_path"),
+                "output_paths": result.get("output_paths", []),
+            }
+
+            if task == "point":
+                response["description"] = (
+                    f"Molmo2 point grounding completed on {len(image_paths)} image(s), "
+                    f"returning {response['result']['num_points']} point(s)."
+                )
+                response["summary"] = response["description"]
+            else:
+                response["summary"] = generated_text[:240]
+                response["description"] = (
+                    f"Molmo2 {task} completed on {len(image_paths)} image(s). "
+                    f"Generated response: {generated_text[:180]}"
+                )
+
+            return response
+        except Exception as e:
+            logger.error("Molmo2Tool error: %s", e)
+            return {"success": False, "error": str(e)}

--- a/test/test_molmo2_expert.py
+++ b/test/test_molmo2_expert.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for Molmo2 expert (mock client + HTTP client with mocks).
+
+Run from repo root:
+  python -m unittest test.test_molmo2_expert -v
+"""
+
+import base64
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+from spagent.external_experts.Molmo2.mock_molmo2_service import MockMolmo2
+from spagent.external_experts.Molmo2.molmo2_client import Molmo2Client
+from spagent.tools.molmo2_tool import Molmo2Tool
+
+
+class TestMockMolmo2(unittest.TestCase):
+    def test_infer_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            f.write(b"\xff\xd8\xff\xd9")
+            path = f.name
+        try:
+            m = MockMolmo2()
+            r = m.infer_path(path, prompt="Hello")
+            self.assertTrue(r.get("success"))
+            self.assertIn("mock", r.get("text", ""))
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_missing_file(self):
+        r = MockMolmo2().infer_path("/nonexistent/no.jpg")
+        self.assertFalse(r.get("success"))
+
+
+class TestMolmo2Client(unittest.TestCase):
+    @patch("spagent.external_experts.Molmo2.molmo2_client.requests.post")
+    def test_infer_success(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"success": True, "text": "a cat"}
+        mock_post.return_value = mock_resp
+
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            f.write(b"\xff\xd8\xff\xd9")
+            path = f.name
+        try:
+            c = Molmo2Client(server_url="http://127.0.0.1:9")
+            out = c.infer_path(path, prompt="What?")
+            self.assertTrue(out.get("success"))
+            self.assertEqual(out.get("text"), "a cat")
+            mock_post.assert_called_once()
+            body = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+            self.assertIn("image", body)
+            base64.b64decode(body["image"])
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+
+class TestMolmo2Tool(unittest.TestCase):
+    def test_tool_mock_call(self):
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            f.write(b"\xff\xd8\xff\xd9")
+            path = f.name
+        try:
+            t = Molmo2Tool(use_mock=True)
+            r = t.call(path, prompt="Describe")
+            self.assertTrue(r.get("success"))
+            self.assertIn("text", r)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_molmo2_tool.py
+++ b/test/test_molmo2_tool.py
@@ -1,0 +1,42 @@
+"""
+Mock-based tests for Molmo2Tool.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.append(str(project_root))
+
+from spagent.tools import Molmo2Tool
+
+
+ASSET_IMAGE = str(project_root / "assets" / "dog.jpeg")
+
+
+def test_molmo2_mock_qa():
+    tool = Molmo2Tool(use_mock=True)
+    result = tool.call(
+        image_path=ASSET_IMAGE,
+        task="qa",
+        prompt="What is shown in this image?",
+    )
+
+    assert result["success"] is True
+    assert "generated_text" in result["result"]
+    assert result["result"]["task"] == "qa"
+
+
+def test_molmo2_mock_point(tmp_path):
+    tool = Molmo2Tool(use_mock=True, output_dir=str(tmp_path))
+    result = tool.call(
+        image_path=ASSET_IMAGE,
+        task="point",
+        prompt="Point to the dog.",
+        save_annotated=True,
+    )
+
+    assert result["success"] is True
+    assert result["result"]["task"] == "point"
+    assert result["result"]["num_points"] >= 1
+    assert result["output_path"] is not None

--- a/test/test_molmo2_tool.py
+++ b/test/test_molmo2_tool.py
@@ -1,23 +1,50 @@
 """
-Mock-based tests for Molmo2Tool.
+Tests for Molmo2Tool (mock and optional live server).
+
+Mock (no GPU / no server):
+  conda activate /home/zzb/anaconda3/envs/spagent
+  cd /home/zzb/projects/spagent
+  pytest test/test_molmo2_tool.py -v
+
+Live server (Molmo2 must be running, e.g. port 20025):
+  export MOLMO2_LIVE_TEST=1
+  export MOLMO2_SERVER_URL=http://127.0.0.1:20025
+  pytest test/test_molmo2_tool.py -v -k live
+
+CLI (see test/test_tool.py):
+  python test/test_tool.py --tool molmo2 --image path/to.jpg --task qa --prompt "Describe" \\
+    --server_url http://127.0.0.1:20025
 """
 
+import os
 import sys
 from pathlib import Path
 
+import pytest
+from PIL import Image
+
 project_root = Path(__file__).parent.parent
-sys.path.append(str(project_root))
+sys.path.insert(0, str(project_root))
 
 from spagent.tools import Molmo2Tool
 
+ASSET_IMAGE = project_root / "assets" / "dog.jpeg"
 
-ASSET_IMAGE = str(project_root / "assets" / "dog.jpeg")
+
+@pytest.fixture
+def sample_image_path(tmp_path):
+    """Prefer repo asset; otherwise a tiny JPEG in tmp_path."""
+    if ASSET_IMAGE.is_file():
+        return str(ASSET_IMAGE)
+    p = tmp_path / "molmo2_sample.jpg"
+    Image.new("RGB", (128, 128), color=(90, 120, 60)).save(p, format="JPEG")
+    return str(p)
 
 
-def test_molmo2_mock_qa():
+def test_molmo2_mock_qa(sample_image_path):
     tool = Molmo2Tool(use_mock=True)
     result = tool.call(
-        image_path=ASSET_IMAGE,
+        image_path=sample_image_path,
         task="qa",
         prompt="What is shown in this image?",
     )
@@ -27,10 +54,10 @@ def test_molmo2_mock_qa():
     assert result["result"]["task"] == "qa"
 
 
-def test_molmo2_mock_point(tmp_path):
+def test_molmo2_mock_point(tmp_path, sample_image_path):
     tool = Molmo2Tool(use_mock=True, output_dir=str(tmp_path))
     result = tool.call(
-        image_path=ASSET_IMAGE,
+        image_path=sample_image_path,
         task="point",
         prompt="Point to the dog.",
         save_annotated=True,
@@ -40,3 +67,17 @@ def test_molmo2_mock_point(tmp_path):
     assert result["result"]["task"] == "point"
     assert result["result"]["num_points"] >= 1
     assert result["output_path"] is not None
+
+
+@pytest.mark.skipif(not os.environ.get("MOLMO2_LIVE_TEST"), reason="Set MOLMO2_LIVE_TEST=1 to run")
+def test_molmo2_live_qa(sample_image_path):
+    url = os.environ.get("MOLMO2_SERVER_URL", "http://127.0.0.1:20025")
+    tool = Molmo2Tool(use_mock=False, server_url=url)
+    result = tool.call(
+        image_path=sample_image_path,
+        task="qa",
+        prompt="What is in this image? One short sentence.",
+        max_new_tokens=64,
+    )
+    assert result["success"] is True
+    assert result["result"]["generated_text"].strip()

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -35,6 +35,12 @@ Usage:
     # Test with mock service (no API keys needed)
     python test/test_tool.py --tool veo --image dummy --prompt "test video" --use_mock
     python test/test_tool.py --tool sora --image dummy --prompt "test video" --use_mock
+
+    # Test Molmo2 (real server)
+    python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20035
+
+    # Test Molmo2 (mock mode)
+    python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task point --prompt "Point to the dog" --use_mock --save_annotated
 """
 
 import sys
@@ -53,6 +59,12 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
 
 
 # ============================================================
@@ -286,6 +298,70 @@ def test_detection(
 
 
 # ============================================================
+# Molmo2 Tool Test
+# ============================================================
+
+def test_molmo2(
+    image_paths: List[str],
+    task: str = "qa",
+    prompt: Optional[str] = None,
+    server_url: str = "http://localhost:20035",
+    use_mock: bool = True,
+    save_annotated: bool = True,
+    output_dir: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Directly test Molmo2 multimodal reasoning / pointing tool.
+    """
+    from spagent.tools import Molmo2Tool
+
+    for p in image_paths:
+        if not os.path.exists(p):
+            logger.error(f"Image not found: {p}")
+            return None
+
+    logger.info("=" * 60)
+    logger.info("Molmo2 Tool Test")
+    logger.info("=" * 60)
+    logger.info(f"  Input images     : {image_paths}")
+    logger.info(f"  Task             : {task}")
+    logger.info(f"  Prompt           : {prompt or '(tool default)'}")
+    logger.info(f"  Server URL       : {server_url}")
+    logger.info(f"  Use mock         : {use_mock}")
+    logger.info(f"  Save annotated   : {save_annotated}")
+    logger.info(f"  Output dir       : {output_dir or '(system temp)'}")
+    logger.info("-" * 60)
+
+    tool = Molmo2Tool(
+        use_mock=use_mock,
+        server_url=server_url,
+        output_dir=output_dir,
+    )
+
+    result = tool.call(
+        image_path=image_paths if len(image_paths) > 1 else image_paths[0],
+        task=task,
+        prompt=prompt,
+        save_annotated=save_annotated,
+    )
+
+    if not result.get("success"):
+        logger.error(f"Molmo2 tool failed: {result.get('error', 'unknown error')}")
+        return None
+
+    logger.info("Molmo2 tool succeeded!")
+    logger.info(f"  Response         : {result.get('response_text', '')[:200]}")
+
+    output_path = result.get("output_path")
+    if output_path and os.path.exists(output_path):
+        logger.info(f"  Output saved     : {output_path}")
+        return output_path
+
+    logger.info("  No output image generated for this task.")
+    return "OK"
+
+
+# ============================================================
 # Veo Video Generation Tool Test
 # ============================================================
 
@@ -450,7 +526,7 @@ def parse_args():
         "--tool",
         type=str,
         required=True,
-        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora"],
+        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora", "molmo2"],
         help="Which tool to test.",
     )
     parser.add_argument(
@@ -508,6 +584,20 @@ def parse_args():
         help="Text prompt for object detection (default: 'object'). Also used as the video prompt for veo/sora.",
     )
 
+    molmo2_group = parser.add_argument_group("Molmo2 options")
+    molmo2_group.add_argument(
+        "--task",
+        type=str,
+        default="qa",
+        choices=["qa", "caption", "point"],
+        help="Molmo2 task mode (default: qa).",
+    )
+    molmo2_group.add_argument(
+        "--save_annotated",
+        action="store_true",
+        help="Save annotated image(s) when task=point.",
+    )
+
     # --- Video generation (Veo / Sora) specific ---
     vid_group = parser.add_argument_group("Video generation options (Veo / Sora)")
     vid_group.add_argument(
@@ -541,7 +631,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    image_required_tools = {"pi3", "pi3x", "depth", "segmentation", "detection"}
+    image_required_tools = {"pi3", "pi3x", "depth", "segmentation", "detection", "molmo2"}
     if args.tool in image_required_tools and not args.image:
         print(f"Error: --image is required for tool '{args.tool}'")
         sys.exit(1)
@@ -614,6 +704,18 @@ def main():
             aspect_ratio=args.aspect_ratio,
             use_mock=args.use_mock,
             output_dir=args.output_dir,
+        )
+
+    elif args.tool == "molmo2":
+        server = args.server_url or "http://localhost:20035"
+        result_path = test_molmo2(
+            image_paths=args.image,
+            task=args.task,
+            prompt=None if args.task == "caption" and args.prompt == "object" else args.prompt,
+            server_url=server,
+            use_mock=args.use_mock,
+            save_annotated=args.save_annotated,
+            output_dir=None if args.output_dir == "outputs/tool_test" else args.output_dir,
         )
 
     # --- summary ---

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -37,7 +37,7 @@ Usage:
     python test/test_tool.py --tool sora --image dummy --prompt "test video" --use_mock
 
     # Test Molmo2 (real server)
-    python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20035
+    python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task qa --prompt "Describe the dog" --server_url http://localhost:20025
 
     # Test Molmo2 (mock mode)
     python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task point --prompt "Point to the dog" --use_mock --save_annotated
@@ -305,7 +305,7 @@ def test_molmo2(
     image_paths: List[str],
     task: str = "qa",
     prompt: Optional[str] = None,
-    server_url: str = "http://localhost:20035",
+    server_url: str = "http://localhost:20025",
     use_mock: bool = True,
     save_annotated: bool = True,
     output_dir: Optional[str] = None,
@@ -707,7 +707,7 @@ def main():
         )
 
     elif args.tool == "molmo2":
-        server = args.server_url or "http://localhost:20035"
+        server = args.server_url or "http://localhost:20025"
         result_path = test_molmo2(
             image_paths=args.image,
             task=args.task,


### PR DESCRIPTION
### Summary

This PR adds `Molmo2` to SPAgent following the project's mainstream external expert integration pattern.

The integration includes:
- a new `Molmo2Tool`
- a real local deployment path based on `tool -> client -> server -> local runtime`
- a mock service for development and testing
- tool export and plugin auto-registration
- direct tool tests
- English and Chinese documentation updates

### Main Changes

#### 1. Added Molmo2 tool wrapper

- Added `spagent/spagent/tools/molmo2_tool.py`
- Supports:
  - `qa`
  - `caption`
  - `point`
- Supports both single-image and multi-image inputs

#### 2. Added Molmo2 external expert module

Added:
- `spagent/spagent/external_experts/Molmo2/__init__.py`
- `spagent/spagent/external_experts/Molmo2/molmo2_local.py`
- `spagent/spagent/external_experts/Molmo2/molmo2_client.py`
- `spagent/spagent/external_experts/Molmo2/molmo2_server.py`
- `spagent/spagent/external_experts/Molmo2/mock_molmo2_service.py`
- `spagent/spagent/external_experts/Molmo2/point_utils.py`

This keeps Molmo2 aligned with the repo's mainstream pattern for heavy tools:
- thin tool wrapper
- HTTP client
- local inference server
- isolated real runtime
- mock service for testing

#### 3. Registered Molmo2 in SPAgent

- Exported `Molmo2Tool` from `spagent/spagent/tools/__init__.py`
- Added plugin auto-registration in `spagent/plugin/plugin.py`

#### 4. Added tests and direct tool runner support

- Added `spagent/test/test_molmo2_tool.py`
- Updated `spagent/test/test_tool.py`
- Added direct CLI test support for Molmo2

#### 5. Updated documentation

- Updated `spagent/readme.md`
- Updated `spagent/docs/Tool/TOOL_USING.md`
- Updated `spagent/docs/Tool/TOOL_USING_ZH.md`

### Notes

- Real mode runs as a local service on port `20035`
- Mock mode is available for development and validation
- Annotated point outputs default to the system temp directory instead of repo-local `outputs/`

### Validation

Executed locally:
- `python -m pytest -q test/test_molmo2_tool.py`
- `python -c "from spagent.tools import Molmo2Tool; print(Molmo2Tool.__name__)"`
- `python test/test_tool.py --tool molmo2 --image assets/dog.jpeg --task point --prompt "Point to the dog" --use_mock --save_annotated`
- `python -c "from spagent.external_experts.Molmo2.molmo2_server import app; print(app.name)"`

### Commit Structure

This work was split into four commits:

1. `add Molmo2 external expert runtime and tool wrapper`
2. `register Molmo2 tool in exports and plugin`
3. `add Molmo2 direct tests and mock coverage`
4. `document Molmo2 deployment and usage`