### PR TITLE
Feat/oneformer

### DIFF
--- a/docs/Tool/EXTERNAL_EXPERTS.md
+++ b/docs/Tool/EXTERNAL_EXPERTS.md
@@ -27,6 +27,7 @@ Full list of supported external expert models in SPAgent, their default ports, a
 | **WildDet3D** | 3D | Promptable 3D Object Detection | Local (no server) | Text/box/point prompts; requires `WILDDET3D_ROOT` and `WILDDET3D_CHECKPOINT` env vars |
 | **FlowSeek** | 2D | Optical Flow Estimation | Local / server (20036) | Dense per-pixel motion between two images; M (ViT-B) or T (ViT-S) variants |
 | **PaddleOCR-VL-1.5** | OCR | Document OCR & Structured Recognition | Local or server (20037) | Plain OCR, table, chart, formula→LaTeX, seal recognition; auto-downloads from HuggingFace |
+| **OneFormer** | 2D | Universal Image Segmentation | Local / server (20035) | semantic / instance / panoptic; HF auto-download; returns mask_path |
 
 ## Port Summary
 
@@ -44,6 +45,7 @@ Full list of supported external expert models in SPAgent, their default ports, a
 | 20034 | OrientAnythingV2 |
 | 20035 | VACE |
 | 20036 | FlowSeek |
+| 20035 | OneFormer |
 | 20037 | PaddleOCR-VL-1.5 |
 | 30000 | Sana (SGLang) |
 

--- a/docs/Tool/EXTERNAL_EXPERTS.md
+++ b/docs/Tool/EXTERNAL_EXPERTS.md
@@ -27,7 +27,7 @@ Full list of supported external expert models in SPAgent, their default ports, a
 | **WildDet3D** | 3D | Promptable 3D Object Detection | Local (no server) | Text/box/point prompts; requires `WILDDET3D_ROOT` and `WILDDET3D_CHECKPOINT` env vars |
 | **FlowSeek** | 2D | Optical Flow Estimation | Local / server (20036) | Dense per-pixel motion between two images; M (ViT-B) or T (ViT-S) variants |
 | **PaddleOCR-VL-1.5** | OCR | Document OCR & Structured Recognition | Local or server (20037) | Plain OCR, table, chart, formula→LaTeX, seal recognition; auto-downloads from HuggingFace |
-| **OneFormer** | 2D | Universal Image Segmentation | Local / server (20035) | semantic / instance / panoptic; HF auto-download; returns mask_path |
+| **OneFormer** | 2D | Universal Image Segmentation | Local / server (20038) | semantic / instance / panoptic; HF auto-download; returns mask_path |
 
 ## Port Summary
 
@@ -45,8 +45,8 @@ Full list of supported external expert models in SPAgent, their default ports, a
 | 20034 | OrientAnythingV2 |
 | 20035 | VACE |
 | 20036 | FlowSeek |
-| 20035 | OneFormer |
 | 20037 | PaddleOCR-VL-1.5 |
+| 20038 | OneFormer |
 | 30000 | Sana (SGLang) |
 
 For deployment instructions, see **[TOOL_USING.md](TOOL_USING.md)**.

--- a/docs/Tool/TOOL_USING.md
+++ b/docs/Tool/TOOL_USING.md
@@ -33,7 +33,7 @@ external_experts/
 ├── WildDet3D/                     # Promptable 3D object detection (local, no server)
 ├── FlowSeek/                      # Optical flow estimation between image pairs (local or server port 20036)
 ├── PaddleOCRVL/                   # Document OCR & structured recognition (PaddleOCR-VL-1.5, port 20037)
-├── OneFormer/                     # Universal image segmentation semantic/instance/panoptic (port 20035)
+├── OneFormer/                     # Universal image segmentation semantic/instance/panoptic (port 20038)
 └── supervision/                   # YOLO object detection and annotation tools
 ```
 
@@ -61,7 +61,7 @@ external_experts/
 | **WildDet3D** | `WildDet3DTool` | Promptable 3D Object Detection | Detect and localize objects in 2D and 3D from a single RGB image; supports text, box, and point prompts; requires `WILDDET3D_ROOT` and `WILDDET3D_CHECKPOINT` env vars | Local (no server) | `image_path`, `prompt_text`(optional), `input_boxes`(optional), `input_points`(optional) |
 | **FlowSeek** | `FlowSeekTool` | Optical Flow Estimation | Estimate dense per-pixel motion between two images (consecutive frames or before/after pairs); returns colorized flow visualization; M variant (ViT-B) or T variant (ViT-S); source vendored in repo, requires `FLOWSEEK_CHECKPOINT` and `FLOWSEEK_DAV2_CHECKPOINT` env vars | Local / Server (port 20036) | `image1_path`, `image2_path`, `output_path`(optional) |
 | **PaddleOCR-VL-1.5** | `PaddleOCRVLTool` | Document OCR & Structured Recognition | 0.9B VLM for plain OCR, table parsing, chart reading, formula → LaTeX, text spotting, and seal recognition; supports local/server/mock; no checkpoint env var required | Local or Server (port 20037) | `image_path`, `task` ("ocr" / "table" / "chart" / "formula" / "spotting" / "seal") |
-| **OneFormer** | `OneFormerTool` | Universal Image Segmentation | Single model for semantic / instance / panoptic; HF auto-download; returns colorized overlay + mask_path id-map | Local / Server (port 20035) | `image_path`, `task` ("semantic" / "instance" / "panoptic") |
+| **OneFormer** | `OneFormerTool` | Universal Image Segmentation | Single model for semantic / instance / panoptic; HF auto-download; returns colorized overlay + mask_path id-map | Local / Server (port 20038) | `image_path`, `task` ("semantic" / "instance" / "panoptic") |
 
 **Usage Examples**:
 - For detailed usage examples, please refer to: [Advanced Examples](../Examples/ADVANCED_EXAMPLES.md)
@@ -1486,7 +1486,7 @@ print(result["answer"])
 
 **Features**:
 - Three tasks via one checkpoint: `semantic`, `instance`, `panoptic`
-- Local, server (port 20035), and mock modes
+- Local, server (port 20038), and mock modes
 - Auto-downloads from HuggingFace Hub on first use
 - Returns colorized visualization (`output_path`) and integer id mask (`mask_path`) for the standardized segmentation contract
 
@@ -1509,11 +1509,11 @@ print(result["output_path"], result.get("mask_path"))
 **Server mode**:
 
 ```bash
-python spagent/external_experts/OneFormer/oneformer_server.py --port 20035 --device cuda
+python spagent/external_experts/OneFormer/oneformer_server.py --port 20038 --device cuda
 ```
 
 ```python
-tool = OneFormerTool(server_url="http://localhost:20035")
+tool = OneFormerTool(server_url="http://localhost:20038")
 ```
 
 **Test**:

--- a/docs/Tool/TOOL_USING.md
+++ b/docs/Tool/TOOL_USING.md
@@ -33,6 +33,7 @@ external_experts/
 ├── WildDet3D/                     # Promptable 3D object detection (local, no server)
 ├── FlowSeek/                      # Optical flow estimation between image pairs (local or server port 20036)
 ├── PaddleOCRVL/                   # Document OCR & structured recognition (PaddleOCR-VL-1.5, port 20037)
+├── OneFormer/                     # Universal image segmentation semantic/instance/panoptic (port 20035)
 └── supervision/                   # YOLO object detection and annotation tools
 ```
 
@@ -60,6 +61,7 @@ external_experts/
 | **WildDet3D** | `WildDet3DTool` | Promptable 3D Object Detection | Detect and localize objects in 2D and 3D from a single RGB image; supports text, box, and point prompts; requires `WILDDET3D_ROOT` and `WILDDET3D_CHECKPOINT` env vars | Local (no server) | `image_path`, `prompt_text`(optional), `input_boxes`(optional), `input_points`(optional) |
 | **FlowSeek** | `FlowSeekTool` | Optical Flow Estimation | Estimate dense per-pixel motion between two images (consecutive frames or before/after pairs); returns colorized flow visualization; M variant (ViT-B) or T variant (ViT-S); source vendored in repo, requires `FLOWSEEK_CHECKPOINT` and `FLOWSEEK_DAV2_CHECKPOINT` env vars | Local / Server (port 20036) | `image1_path`, `image2_path`, `output_path`(optional) |
 | **PaddleOCR-VL-1.5** | `PaddleOCRVLTool` | Document OCR & Structured Recognition | 0.9B VLM for plain OCR, table parsing, chart reading, formula → LaTeX, text spotting, and seal recognition; supports local/server/mock; no checkpoint env var required | Local or Server (port 20037) | `image_path`, `task` ("ocr" / "table" / "chart" / "formula" / "spotting" / "seal") |
+| **OneFormer** | `OneFormerTool` | Universal Image Segmentation | Single model for semantic / instance / panoptic; HF auto-download; returns colorized overlay + mask_path id-map | Local / Server (port 20035) | `image_path`, `task` ("semantic" / "instance" / "panoptic") |
 
 **Usage Examples**:
 - For detailed usage examples, please refer to: [Advanced Examples](../Examples/ADVANCED_EXAMPLES.md)
@@ -1475,6 +1477,54 @@ print(result["answer"])
 **Resources**:
 - [PaddleOCR-VL-1.5 on HuggingFace](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5)
 - [Paper](https://arxiv.org/abs/2505.09816)
+
+---
+
+### 17. OneFormer - Universal Image Segmentation
+
+**Function**: Universal image segmentation (semantic / instance / panoptic) with a single model.
+
+**Features**:
+- Three tasks via one checkpoint: `semantic`, `instance`, `panoptic`
+- Local, server (port 20035), and mock modes
+- Auto-downloads from HuggingFace Hub on first use
+- Returns colorized visualization (`output_path`) and integer id mask (`mask_path`) for the standardized segmentation contract
+
+**Setup**:
+
+```bash
+pip install transformers Pillow
+export ONEFORMER_MODEL_ID=shi-labs/oneformer_ade20k_swin_large  # optional
+```
+
+**Local usage**:
+
+```python
+from spagent.tools import OneFormerTool
+tool = OneFormerTool(device="cuda")
+result = tool.call(image_path="image.jpg", task="panoptic")
+print(result["output_path"], result.get("mask_path"))
+```
+
+**Server mode**:
+
+```bash
+python spagent/external_experts/OneFormer/oneformer_server.py --port 20035 --device cuda
+```
+
+```python
+tool = OneFormerTool(server_url="http://localhost:20035")
+```
+
+**Test**:
+
+```bash
+python test/test_tool.py --tool oneformer --image assets/dog.jpeg --use_mock
+python test/test_tool.py --tool oneformer --image assets/dog.jpeg --seg_task panoptic
+```
+
+**Resources**:
+- [OneFormer GitHub](https://github.com/SHI-Labs/OneFormer)
 
 ---
 

--- a/examples/evaluation/evaluate_img.py
+++ b/examples/evaluation/evaluate_img.py
@@ -29,6 +29,7 @@ from spagent.tools import (
     VaceTool,
     WildDet3DTool,
     FlowSeekTool,
+    OneFormerTool,
 )
 from spagent.utils.utils import (
     load_json_data, 
@@ -66,6 +67,9 @@ TOOL_CONFIGS = {
     ],
     "flowseek": [
         FlowSeekTool(device="cuda"),
+    ],
+    "oneformer": [
+        OneFormerTool(device="cuda"),
     ],
 }
 

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ export GOOGLE_API_KEY="your_google_api_key"
 
 ### 3. Deploy Expert Servers
 
-See **[Tool Reference](docs/Tool/TOOL_USING.md)** for per-tool deployment instructions (Depth, SAM2, GroundingDINO, Pi3, Molmo2, OrientAnythingV2, WildDet3D, FlowSeek, PaddleOCR-VL, Sana, VACE, …).
+See **[Tool Reference](docs/Tool/TOOL_USING.md)** for per-tool deployment instructions (Depth, SAM2, GroundingDINO, Pi3, Molmo2, OrientAnythingV2, WildDet3D, FlowSeek, PaddleOCR-VL, OneFormer, Sana, VACE, …).
 
 ## 🚀 Quick Start
 

--- a/spagent/external_experts/OneFormer/__init__.py
+++ b/spagent/external_experts/OneFormer/__init__.py
@@ -1,0 +1,4 @@
+from .oneformer_local import OneFormerLocalClient
+from .oneformer_client import OneFormerClient
+
+__all__ = ["OneFormerLocalClient", "OneFormerClient"]

--- a/spagent/external_experts/OneFormer/oneformer_client.py
+++ b/spagent/external_experts/OneFormer/oneformer_client.py
@@ -1,0 +1,114 @@
+"""
+OneFormer HTTP client.
+
+Communicates with oneformer_server.py. Use this when the model runs as a
+separate service and you want to avoid loading weights into the current process.
+
+Usage:
+    from external_experts.OneFormer.oneformer_client import OneFormerClient
+    client = OneFormerClient("http://localhost:20035")
+    result = client.segment("image.jpg", task="panoptic")
+"""
+
+import base64
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class OneFormerClient:
+    """Lightweight HTTP client for the OneFormer server."""
+
+    def __init__(self, server_url: str, timeout: int = 120):
+        self.server_url = server_url.rstrip("/")
+        self.timeout = timeout
+
+    def health_check(self) -> Optional[Dict]:
+        try:
+            resp = requests.get(f"{self.server_url}/health", timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            logger.error("Health check failed: %s", e)
+            return None
+
+    def segment(
+        self,
+        image_path: str,
+        task: str = "panoptic",
+    ) -> Dict[str, Any]:
+        """
+        Segment an image using the remote OneFormer server.
+
+        Args:
+            image_path: Local path to the input image.
+            task: One of 'semantic', 'instance', 'panoptic'.
+
+        Returns:
+            dict with keys: success, task, segments, num_segments,
+                            output_path, description
+        """
+        if not Path(image_path).exists():
+            return {"success": False, "error": f"Image not found: {image_path}"}
+
+        try:
+            import cv2
+
+            img = cv2.imread(image_path)
+            if img is None:
+                return {"success": False, "error": f"Could not read image: {image_path}"}
+
+            _, buffer = cv2.imencode(".jpg", img)
+            image_b64 = base64.b64encode(buffer.tobytes()).decode("utf-8")
+
+            payload = {"image": image_b64, "task": task}
+
+            resp = requests.post(
+                f"{self.server_url}/infer",
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+
+            if not result.get("success"):
+                return result
+
+            # Save annotated image + id mask locally if server returned them
+            os.makedirs("outputs", exist_ok=True)
+            stem = Path(image_path).stem
+            output_path = image_path  # fallback
+            mask_path = None
+            if result.get("annotated_image"):
+                annotated_bytes = base64.b64decode(result["annotated_image"])
+                output_path = f"outputs/oneformer_{task}_{stem}.png"
+                with open(output_path, "wb") as f:
+                    f.write(annotated_bytes)
+                logger.info("Annotated image saved: %s", output_path)
+            if result.get("mask_image"):
+                mask_bytes = base64.b64decode(result["mask_image"])
+                mask_path = f"outputs/oneformer_{task}_{stem}_mask.png"
+                with open(mask_path, "wb") as f:
+                    f.write(mask_bytes)
+                logger.info("Mask image saved: %s", mask_path)
+
+            return {
+                "success": True,
+                "task": result["task"],
+                "segments": result["segments"],
+                "num_segments": result["num_segments"],
+                "output_path": output_path,
+                "mask_path": mask_path,
+                "shape": result.get("shape"),
+                "description": result["description"],
+            }
+
+        except Exception as e:
+            logger.exception("OneFormerClient.segment error")
+            return {"success": False, "error": str(e)}

--- a/spagent/external_experts/OneFormer/oneformer_client.py
+++ b/spagent/external_experts/OneFormer/oneformer_client.py
@@ -6,7 +6,7 @@ separate service and you want to avoid loading weights into the current process.
 
 Usage:
     from external_experts.OneFormer.oneformer_client import OneFormerClient
-    client = OneFormerClient("http://localhost:20035")
+    client = OneFormerClient("http://localhost:20038")
     result = client.segment("image.jpg", task="panoptic")
 """
 

--- a/spagent/external_experts/OneFormer/oneformer_local.py
+++ b/spagent/external_experts/OneFormer/oneformer_local.py
@@ -1,0 +1,234 @@
+"""
+OneFormer local inference client.
+
+Loads model via HuggingFace Transformers — no manual checkpoint download needed.
+Supports three segmentation tasks: semantic, instance, panoptic.
+
+Environment variable:
+    ONEFORMER_MODEL_ID  — HuggingFace model ID (default: shi-labs/oneformer_ade20k_swin_large)
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL_ID = "shi-labs/oneformer_ade20k_swin_large"
+
+# ADE20k color palette (150 classes), truncated/extended as needed
+_ADE20K_PALETTE = [
+    [120, 120, 120], [180, 120, 120], [6, 230, 230], [80, 50, 50],
+    [4, 200, 3], [120, 120, 80], [140, 140, 140], [204, 5, 255],
+    [230, 230, 230], [4, 250, 7], [224, 5, 255], [235, 255, 7],
+    [150, 5, 61], [120, 120, 70], [8, 255, 51], [255, 6, 82],
+    [143, 255, 140], [204, 255, 4], [255, 51, 7], [204, 70, 3],
+    [0, 102, 200], [61, 230, 250], [255, 6, 51], [11, 102, 255],
+    [255, 7, 71], [255, 9, 224], [9, 7, 230], [220, 220, 220],
+    [255, 9, 92], [112, 9, 255], [8, 255, 214], [7, 255, 224],
+    [255, 184, 6], [10, 255, 71], [255, 41, 10], [7, 255, 255],
+    [224, 255, 8], [102, 8, 255], [255, 61, 6], [255, 194, 7],
+    [255, 122, 8], [0, 255, 20], [255, 8, 41], [255, 5, 153],
+    [6, 51, 255], [235, 12, 255], [160, 150, 20], [0, 163, 255],
+    [140, 140, 140], [250, 10, 15], [20, 255, 0], [31, 255, 0],
+    [255, 31, 0], [255, 224, 0], [153, 255, 0], [0, 0, 255],
+    [255, 71, 0], [0, 235, 255], [0, 173, 255], [31, 0, 255],
+    [11, 200, 200], [255, 82, 0], [0, 255, 245], [0, 61, 255],
+    [0, 255, 112], [0, 255, 133], [255, 0, 0], [255, 163, 0],
+    [255, 102, 0], [194, 255, 0], [0, 143, 255], [51, 255, 0],
+    [0, 82, 255], [0, 255, 41], [0, 255, 173], [10, 0, 255],
+    [173, 255, 0], [0, 255, 153], [255, 92, 0], [255, 0, 255],
+    [255, 0, 245], [255, 0, 102], [255, 173, 0], [255, 0, 20],
+    [255, 184, 184], [0, 31, 255], [0, 255, 61], [0, 71, 255],
+    [255, 0, 204], [0, 255, 194], [0, 255, 82], [0, 10, 255],
+    [0, 112, 255], [51, 0, 255], [0, 194, 255], [0, 122, 255],
+    [0, 255, 163], [255, 153, 0], [0, 255, 10], [255, 112, 0],
+    [143, 255, 0], [82, 0, 255], [163, 255, 0], [255, 235, 0],
+    [8, 184, 170], [133, 0, 255], [0, 255, 92], [184, 0, 255],
+    [255, 0, 31], [0, 184, 255], [0, 214, 255], [255, 0, 112],
+    [92, 255, 0], [0, 224, 255], [112, 224, 255], [70, 184, 160],
+    [163, 0, 255], [153, 0, 255], [71, 255, 0], [255, 0, 163],
+    [255, 204, 0], [255, 0, 143], [0, 255, 235], [133, 255, 0],
+    [255, 0, 235], [245, 0, 255], [255, 0, 122], [255, 245, 0],
+    [10, 190, 212], [214, 255, 0], [0, 204, 255], [20, 0, 255],
+    [255, 255, 0], [0, 153, 255], [0, 41, 255], [0, 255, 204],
+    [41, 0, 255], [41, 255, 0], [173, 0, 255], [0, 245, 255],
+    [71, 0, 255], [122, 0, 255], [0, 255, 184], [0, 92, 255],
+    [184, 255, 0], [0, 133, 255], [255, 214, 0], [25, 194, 194],
+    [102, 255, 0], [92, 0, 255],
+]
+
+
+class OneFormerLocalClient:
+    """In-process OneFormer client using HuggingFace Transformers."""
+
+    def __init__(self, model_id: Optional[str] = None, device: str = "cuda"):
+        self.model_id = model_id or os.environ.get("ONEFORMER_MODEL_ID", _DEFAULT_MODEL_ID)
+        self.device = device
+        self._processor = None
+        self._model = None
+
+    def _ensure_model_loaded(self):
+        if self._model is not None:
+            return
+
+        import torch
+        from transformers import OneFormerForUniversalSegmentation, OneFormerProcessor
+
+        logger.info("Loading OneFormer processor: %s", self.model_id)
+        self._processor = OneFormerProcessor.from_pretrained(self.model_id)
+
+        logger.info("Loading OneFormer model: %s", self.model_id)
+        self._model = OneFormerForUniversalSegmentation.from_pretrained(self.model_id)
+        self._model.to(self.device)
+        self._model.eval()
+        logger.info("OneFormer model loaded on %s", self.device)
+
+    def segment(
+        self,
+        image_path: str,
+        task: str = "panoptic",
+        output_path: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run segmentation on an image.
+
+        Args:
+            image_path: Path to input image.
+            task: One of 'semantic', 'instance', 'panoptic'.
+            output_path: Where to save annotated image. Auto-generated if None.
+
+        Returns:
+            dict with keys: success, task, output_path, description,
+                            segments (list), num_segments
+        """
+        import torch
+        from PIL import Image
+
+        if task not in ("semantic", "instance", "panoptic"):
+            return {"success": False, "error": f"Invalid task '{task}'. Choose semantic/instance/panoptic."}
+
+        try:
+            self._ensure_model_loaded()
+
+            pil_image = Image.open(image_path).convert("RGB")
+            w, h = pil_image.size
+
+            inputs = self._processor(
+                images=pil_image,
+                task_inputs=[task],
+                return_tensors="pt",
+            )
+            inputs = {k: v.to(self.device) if hasattr(v, "to") else v for k, v in inputs.items()}
+
+            with torch.no_grad():
+                outputs = self._model(**inputs)
+
+            segments = []
+            seg_map = None
+
+            if task == "semantic":
+                seg_map = self._processor.post_process_semantic_segmentation(
+                    outputs, target_sizes=[(h, w)]
+                )[0].cpu().numpy()
+                unique_ids = np.unique(seg_map)
+                id2label = self._model.config.id2label
+                segments = [
+                    {"id": int(uid), "label": id2label.get(int(uid), str(uid))}
+                    for uid in unique_ids
+                ]
+
+            elif task == "instance":
+                result = self._processor.post_process_instance_segmentation(
+                    outputs, target_sizes=[(h, w)]
+                )[0]
+                seg_map = result["segmentation"].cpu().numpy()
+                id2label = self._model.config.id2label
+                segments = [
+                    {
+                        "id": int(s["id"]),
+                        "label": id2label.get(int(s["label_id"]), str(s["label_id"])),
+                        "score": round(float(s["score"]), 4) if "score" in s else None,
+                    }
+                    for s in result["segments_info"]
+                ]
+
+            elif task == "panoptic":
+                result = self._processor.post_process_panoptic_segmentation(
+                    outputs, target_sizes=[(h, w)]
+                )[0]
+                seg_map = result["segmentation"].cpu().numpy()
+                id2label = self._model.config.id2label
+                segments = [
+                    {
+                        "id": int(s["id"]),
+                        "label": id2label.get(int(s["label_id"]), str(s["label_id"])),
+                        "score": round(float(s["score"]), 4) if "score" in s else None,
+                    }
+                    for s in result["segments_info"]
+                ]
+
+            # Build color visualization
+            vis = self._colorize(seg_map, task, segments)
+
+            # Save colorized overlay + integer id mask (contract carrier)
+            stem = Path(image_path).stem
+            os.makedirs("outputs", exist_ok=True)
+            if output_path is None:
+                output_path = f"outputs/oneformer_{task}_{stem}.png"
+            mask_path = f"outputs/oneformer_{task}_{stem}_mask.png"
+
+            import cv2
+            cv2.imwrite(output_path, cv2.cvtColor(vis, cv2.COLOR_RGB2BGR))
+            # Persist segment-id map so ToolResult can satisfy the
+            # segmentation contract via mask_path (uint16 PNG).
+            mask_u16 = np.asarray(seg_map, dtype=np.uint16)
+            cv2.imwrite(mask_path, mask_u16)
+
+            labels = [s["label"] for s in segments[:5]]
+            more = f" and {len(segments) - 5} more" if len(segments) > 5 else ""
+            description = (
+                f"OneFormer {task} segmentation: {len(segments)} segment(s). "
+                f"Labels: {', '.join(labels)}{more}."
+            )
+
+            return {
+                "success": True,
+                "task": task,
+                "output_path": output_path,
+                "mask_path": mask_path,
+                "shape": [int(h), int(w)],
+                "description": description,
+                "segments": segments,
+                "num_segments": len(segments),
+            }
+
+        except Exception as e:
+            logger.exception("OneFormerLocalClient.segment error")
+            return {"success": False, "error": str(e)}
+
+    def _colorize(
+        self,
+        seg_map: np.ndarray,
+        task: str,
+        segments: List[Dict],
+    ) -> np.ndarray:
+        """Produce an RGB visualization of the segmentation map."""
+        h, w = seg_map.shape
+        vis = np.zeros((h, w, 3), dtype=np.uint8)
+
+        if task == "semantic":
+            for uid in np.unique(seg_map):
+                color = _ADE20K_PALETTE[int(uid) % len(_ADE20K_PALETTE)]
+                vis[seg_map == uid] = color
+        else:
+            # instance / panoptic: color by segment id
+            for i, seg in enumerate(segments):
+                sid = seg["id"]
+                color = _ADE20K_PALETTE[i % len(_ADE20K_PALETTE)]
+                vis[seg_map == sid] = color
+
+        return vis

--- a/spagent/external_experts/OneFormer/oneformer_server.py
+++ b/spagent/external_experts/OneFormer/oneformer_server.py
@@ -1,0 +1,141 @@
+"""
+OneFormer Flask inference server.
+
+Wraps OneFormerLocalClient as an HTTP service so multiple agents can share
+one model instance without reloading weights on every call.
+
+Usage:
+    python spagent/external_experts/OneFormer/oneformer_server.py --port 20035
+
+    # With a specific model:
+    python spagent/external_experts/OneFormer/oneformer_server.py \
+        --model_id shi-labs/oneformer_ade20k_swin_large --port 20035 --device cuda
+"""
+
+import argparse
+import base64
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Make external_experts importable regardless of working directory
+_HERE = Path(__file__).resolve().parent
+_SPAGENT = _HERE.parents[1]  # .../spagent/spagent/
+if str(_SPAGENT) not in sys.path:
+    sys.path.insert(0, str(_SPAGENT))
+
+import numpy as np
+from flask import Flask, jsonify, request
+from external_experts.OneFormer.oneformer_local import OneFormerLocalClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+_client = None  # OneFormerLocalClient, set at startup
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@app.route("/health", methods=["GET"])
+def health_check():
+    status = {
+        "status": "healthy" if _client is not None else "not_ready",
+        "model_loaded": _client is not None and _client._model is not None,
+        "model_id": _client.model_id if _client is not None else None,
+        "device": _client.device if _client is not None else None,
+    }
+    return jsonify(status)
+
+
+@app.route("/infer", methods=["POST"])
+def infer():
+    if _client is None:
+        return jsonify({"success": False, "error": "Model not loaded"}), 500
+
+    data = request.get_json()
+    if not data or "image" not in data:
+        return jsonify({"success": False, "error": "Missing 'image' field"}), 400
+
+    task = data.get("task", "panoptic")
+
+    # Decode base64 image → temp file
+    try:
+        import cv2
+        image_bytes = base64.b64decode(data["image"])
+        nparr = np.frombuffer(image_bytes, np.uint8)
+        img_bgr = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+        if img_bgr is None:
+            return jsonify({"success": False, "error": "Could not decode image"}), 400
+    except Exception as e:
+        return jsonify({"success": False, "error": f"Image decode error: {e}"}), 400
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+        tmp_path = tmp.name
+        cv2.imwrite(tmp_path, img_bgr)
+
+    try:
+        result = _client.segment(image_path=tmp_path, task=task)
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    if not result.get("success"):
+        return jsonify(result), 500
+
+    # Encode annotated output + id mask as base64
+    annotated_b64 = None
+    mask_b64 = None
+    output_path = result.get("output_path")
+    mask_path = result.get("mask_path")
+    if output_path and Path(output_path).exists():
+        with open(output_path, "rb") as f:
+            annotated_b64 = base64.b64encode(f.read()).decode("utf-8")
+    if mask_path and Path(mask_path).exists():
+        with open(mask_path, "rb") as f:
+            mask_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+    return jsonify({
+        "success": True,
+        "task": result["task"],
+        "segments": result["segments"],
+        "num_segments": result["num_segments"],
+        "description": result["description"],
+        "shape": result.get("shape"),
+        "annotated_image": annotated_b64,
+        "mask_image": mask_b64,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="OneFormer inference server")
+    parser.add_argument("--model_id", type=str, default=None,
+                        help="HuggingFace model ID (overrides ONEFORMER_MODEL_ID env var)")
+    parser.add_argument("--port", type=int, default=20035, help="Port (default: 20035)")
+    parser.add_argument("--device", type=str, default="cuda", help="Device (default: cuda)")
+    args = parser.parse_args()
+
+    logger.info("Loading OneFormer model...")
+    try:
+        _client = OneFormerLocalClient(model_id=args.model_id, device=args.device)
+        _client._ensure_model_loaded()
+        logger.info("Model loaded. Starting server on port %d", args.port)
+    except Exception as e:
+        logger.error("Failed to load model: %s", e)
+        sys.exit(1)
+
+    app.run(host="0.0.0.0", port=args.port, debug=False)

--- a/spagent/external_experts/OneFormer/oneformer_server.py
+++ b/spagent/external_experts/OneFormer/oneformer_server.py
@@ -5,11 +5,11 @@ Wraps OneFormerLocalClient as an HTTP service so multiple agents can share
 one model instance without reloading weights on every call.
 
 Usage:
-    python spagent/external_experts/OneFormer/oneformer_server.py --port 20035
+    python spagent/external_experts/OneFormer/oneformer_server.py --port 20038
 
     # With a specific model:
     python spagent/external_experts/OneFormer/oneformer_server.py \
-        --model_id shi-labs/oneformer_ade20k_swin_large --port 20035 --device cuda
+        --model_id shi-labs/oneformer_ade20k_swin_large --port 20038 --device cuda
 """
 
 import argparse
@@ -125,7 +125,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="OneFormer inference server")
     parser.add_argument("--model_id", type=str, default=None,
                         help="HuggingFace model ID (overrides ONEFORMER_MODEL_ID env var)")
-    parser.add_argument("--port", type=int, default=20035, help="Port (default: 20035)")
+    parser.add_argument("--port", type=int, default=20038, help="Port (default: 20038)")
     parser.add_argument("--device", type=str, default="cuda", help="Device (default: cuda)")
     args = parser.parse_args()
 

--- a/spagent/tools/__init__.py
+++ b/spagent/tools/__init__.py
@@ -27,6 +27,7 @@ from .sana_tool import SanaTool
 from .wilddet3d_tool import WildDet3DTool
 from .flowseek_tool import FlowSeekTool
 from .paddleocr_vl_tool import PaddleOCRVLTool
+from .oneformer_tool import OneFormerTool
 from .catalog import (
     TOOL_CATALOG,
     build_all_tools,
@@ -63,6 +64,7 @@ __all__ = [
     'WildDet3DTool',
     'FlowSeekTool',
     'PaddleOCRVLTool',
+    'OneFormerTool',
     'TOOL_CATALOG',
     'build_all_tools',
     'build_tools',

--- a/spagent/tools/catalog.py
+++ b/spagent/tools/catalog.py
@@ -79,7 +79,7 @@ DEFAULT_SERVER_URLS: Dict[str, str] = {
     "sana": "http://127.0.0.1:30000",
     "yoloe": "http://127.0.0.1:8000",
     "supervision": "http://127.0.0.1:8000",
-    "oneformer": "http://127.0.0.1:20035",
+    "oneformer": "http://127.0.0.1:20038",
 }
 
 

--- a/spagent/tools/catalog.py
+++ b/spagent/tools/catalog.py
@@ -36,6 +36,7 @@ from .qwenvl_tool import QwenVLTool
 from .flowseek_tool import FlowSeekTool
 from .paddleocr_vl_tool import PaddleOCRVLTool
 from .wilddet3d_tool import WildDet3DTool
+from .oneformer_tool import OneFormerTool
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,7 @@ DEFAULT_SERVER_URLS: Dict[str, str] = {
     "sana": "http://127.0.0.1:30000",
     "yoloe": "http://127.0.0.1:8000",
     "supervision": "http://127.0.0.1:8000",
+    "oneformer": "http://127.0.0.1:20035",
 }
 
 
@@ -97,6 +99,14 @@ TOOL_CATALOG: List[ToolCatalogEntry] = [
         "2d_perception",
         "segment_image_tool",
         {"server_url": DEFAULT_SERVER_URLS["segmentation"]},
+        category="segmentation",
+    ),
+    ToolCatalogEntry(
+        "oneformer",
+        OneFormerTool,
+        "2d_perception",
+        "oneformer_tool",
+        {"server_url": DEFAULT_SERVER_URLS["oneformer"]},
         category="segmentation",
     ),
     ToolCatalogEntry(

--- a/spagent/tools/oneformer_tool.py
+++ b/spagent/tools/oneformer_tool.py
@@ -1,0 +1,226 @@
+"""
+OneFormer Tool — universal image segmentation (semantic / instance / panoptic).
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from core.tool import Tool
+from core.tool_result import SEGMENTATION, SegmentationPayload, ToolResult
+
+logger = logging.getLogger(__name__)
+
+_ENVELOPE_KEYS = (
+    "success", "description", "error", "category", "payload",
+    "output_path", "vis_path", "overlay_path", "crop_paths", "mask_path",
+)
+
+
+class OneFormerTool(Tool):
+    """Universal image segmentation using OneFormer (semantic, instance, panoptic)."""
+
+    def __init__(
+        self,
+        model_id: Optional[str] = None,
+        device: str = "cuda",
+        server_url: Optional[str] = None,
+        use_mock: bool = False,
+    ):
+        super().__init__(
+            name="oneformer_tool",
+            description=(
+                "OneFormer: universal image segmentation supporting three tasks — "
+                "semantic (pixel-level class labels), instance (individual object masks), "
+                "and panoptic (combined semantic + instance). Returns an annotated "
+                "segmentation image, a mask artifact, and a list of detected segments "
+                "with labels and scores."
+            ),
+        )
+        self.use_mock = use_mock
+        self._server_url = server_url
+        self._client = None
+        self._client_kwargs = dict(model_id=model_id, device=device)
+
+    def _ensure_client(self):
+        if self._client is not None:
+            return
+        if self.use_mock:
+            self._client = _MockOneFormerClient()
+        elif self._server_url:
+            from external_experts.OneFormer.oneformer_client import OneFormerClient
+            self._client = OneFormerClient(self._server_url)
+        else:
+            from external_experts.OneFormer.oneformer_local import OneFormerLocalClient
+            self._client = OneFormerLocalClient(**self._client_kwargs)
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "image_path": {
+                    "type": "string",
+                    "description": "Path to the input RGB image.",
+                },
+                "task": {
+                    "type": "string",
+                    "enum": ["semantic", "instance", "panoptic"],
+                    "description": (
+                        "Segmentation task to run. "
+                        "'semantic': label every pixel with a class. "
+                        "'instance': detect and mask individual object instances. "
+                        "'panoptic': combine semantic and instance segmentation. "
+                        "Default: 'panoptic'."
+                    ),
+                },
+            },
+            "required": ["image_path"],
+        }
+
+    def call(
+        self,
+        image_path: Union[str, List[str]],
+        task: str = "panoptic",
+    ) -> Dict[str, Any]:
+        if isinstance(image_path, list):
+            image_path = image_path[0]
+
+        if not Path(image_path).exists():
+            return {"success": False, "error": f"Image not found: {image_path}"}
+
+        if task not in ("semantic", "instance", "panoptic"):
+            return {
+                "success": False,
+                "error": f"Invalid task '{task}'. Choose semantic/instance/panoptic.",
+            }
+
+        try:
+            self._ensure_client()
+            raw = self._client.segment(image_path=image_path, task=task)
+            if not raw.get("success"):
+                return {
+                    "success": False,
+                    "error": raw.get("error", "OneFormer segmentation failed"),
+                }
+
+            mask_path = raw.get("mask_path")
+            masks = raw.get("masks")
+            if masks or mask_path:
+                payload = SegmentationPayload(
+                    masks=masks if masks else None,
+                    mask_path=mask_path,
+                )
+                category = None
+            else:
+                payload = None
+                category = SEGMENTATION
+
+            description = raw.get("description") or (
+                f"OneFormer {task} segmentation: "
+                f"{raw.get('num_segments', 0)} segment(s)."
+            )
+            extras = {k: v for k, v in raw.items() if k not in _ENVELOPE_KEYS}
+            # Keep nested result for legacy consumers
+            extras.setdefault(
+                "result",
+                {
+                    "task": raw.get("task", task),
+                    "segments": raw.get("segments", []),
+                    "num_segments": raw.get("num_segments", 0),
+                    "mask_path": mask_path,
+                },
+            )
+            return ToolResult(
+                success=True,
+                payload=payload,
+                category=category,
+                description=description,
+                output_path=raw.get("output_path"),
+                vis_path=raw.get("output_path"),
+                mask_path=mask_path,
+                **extras,
+            )
+        except Exception as e:
+            logger.exception("OneFormerTool error")
+            return {"success": False, "error": str(e)}
+
+
+class _MockOneFormerClient:
+    def segment(self, image_path: str, task: str = "panoptic", **kwargs) -> Dict[str, Any]:
+        try:
+            from PIL import Image
+            w, h = Image.open(image_path).size
+        except Exception:
+            w, h = 64, 64
+
+        segments = [
+            {"id": 1, "label": "wall", "score": 0.92},
+            {"id": 2, "label": "floor", "score": 0.88},
+            {"id": 3, "label": "chair", "score": 0.75},
+        ]
+
+        stem = Path(image_path).stem
+        out_dir = Path("outputs")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        output_path = str(out_dir / f"oneformer_{task}_{stem}_mock.png")
+        mask_path = str(out_dir / f"oneformer_{task}_{stem}_mock_mask.png")
+
+        # Prefer OpenCV/numpy when available; otherwise write a tiny valid PNG.
+        wrote = False
+        try:
+            import numpy as np
+            import cv2
+            seg_map = np.zeros((h, w), dtype=np.uint16)
+            seg_map[: h // 3, :] = 1
+            seg_map[h // 3 : 2 * h // 3, :] = 2
+            seg_map[2 * h // 3 :, :] = 3
+            color = np.zeros((h, w, 3), dtype=np.uint8)
+            color[seg_map == 1] = (120, 120, 120)
+            color[seg_map == 2] = (180, 120, 120)
+            color[seg_map == 3] = (6, 230, 230)
+            cv2.imwrite(output_path, color)
+            cv2.imwrite(mask_path, seg_map)
+            wrote = True
+        except Exception:
+            pass
+        if not wrote:
+            try:
+                from PIL import Image as PILImage
+                # 3 horizontal bands as L-mode ids
+                px = []
+                for y in range(h):
+                    band = 1 if y < h // 3 else (2 if y < 2 * h // 3 else 3)
+                    px.extend([band] * w)
+                mask_img = PILImage.new("L", (w, h))
+                mask_img.putdata(px)
+                mask_img.save(mask_path)
+                mask_img.convert("RGB").save(output_path)
+                wrote = True
+            except Exception:
+                # Absolute fallback: minimal 1x1 PNG bytes
+                png_1x1 = (
+                    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+                    b"\x00\x00\x00\x01\x08\x00\x00\x00\x00:\x7e\x9b\x55"
+                    b"\x00\x00\x00\nIDATx\x9cc`\x00\x00\x00\x02\x00\x01"
+                    b"\xe5'\xde\xfc\x00\x00\x00\x00IEND\xaeB`\x82"
+                )
+                Path(mask_path).write_bytes(png_1x1)
+                Path(output_path).write_bytes(png_1x1)
+
+        return {
+            "success": True,
+            "task": task,
+            "segments": segments,
+            "num_segments": len(segments),
+            "output_path": output_path,
+            "mask_path": mask_path,
+            "shape": [h, w],
+            "description": (
+                f"[mock] OneFormer {task} segmentation: 3 segments "
+                f"(wall, floor, chair)."
+            ),
+        }

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -67,6 +67,10 @@ Usage:
 
     # Test PaddleOCR-VL-1.5 (server mode)
     python test/test_tool.py --tool paddleocr_vl --image assets/doc.png --server_url http://0.0.0.0:20037
+
+    # Test OneFormer (mock)
+    python test/test_tool.py --tool oneformer --image assets/dog.jpeg --use_mock
+
 """
 
 import sys
@@ -892,6 +896,63 @@ def test_paddleocr_vl(
     return text or "OK"
 
 
+
+# ============================================================
+# OneFormer Tool Test
+# ============================================================
+
+def test_oneformer(
+    image_paths: List[str],
+    task: str = "panoptic",
+    device: str = "cuda",
+    use_mock: bool = False,
+    output_dir: str = "outputs/tool_test",
+    server_url: Optional[str] = None,
+) -> Optional[str]:
+    """Directly test OneFormer universal segmentation tool."""
+    from spagent.tools import OneFormerTool
+
+    image_path = image_paths[0]
+    if not os.path.exists(image_path):
+        logger.error(f"Image not found: {image_path}")
+        return None
+
+    logger.info("=" * 60)
+    logger.info("OneFormer Tool Test")
+    logger.info("=" * 60)
+    logger.info(f"  Image            : {image_path}")
+    logger.info(f"  Task             : {task}")
+    logger.info(f"  Device           : {device}")
+    logger.info(f"  Use mock         : {use_mock}")
+    logger.info(f"  Server URL       : {server_url or 'local'}")
+    logger.info(f"  Output dir       : {output_dir}")
+    logger.info("-" * 60)
+
+    tool = OneFormerTool(device=device, use_mock=use_mock, server_url=server_url)
+    result = tool.call(image_path=image_path, task=task)
+
+    if not result.get("success"):
+        logger.error(f"OneFormer tool failed: {result.get('error', 'unknown error')}")
+        return None
+
+    logger.info("OneFormer segmentation succeeded!")
+    logger.info(f"  Description      : {result.get('description', '')}")
+    logger.info(f"  Mask path        : {result.get('mask_path', '')}")
+
+    src_path = result.get("output_path")
+    if src_path and os.path.exists(src_path):
+        os.makedirs(output_dir, exist_ok=True)
+        import shutil
+        ext = Path(src_path).suffix
+        dst_path = os.path.join(output_dir, f"OneFormer_test{ext}")
+        shutil.copy2(src_path, dst_path)
+        logger.info(f"  Output saved     : {dst_path}")
+        return dst_path
+
+    logger.warning("No output image path in result.")
+    return None
+
+
 # ============================================================
 # CLI entry point
 # ============================================================
@@ -905,7 +966,7 @@ def parse_args():
         "--tool",
         type=str,
         required=True,
-        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora", "vace", "molmo2", "wilddet3d", "flowseek", "paddleocr_vl"],
+        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora", "vace", "molmo2", "wilddet3d", "flowseek", "paddleocr_vl", "oneformer"],
         help="Which tool to test. depth/segmentation/detection now run real inference (no longer stubs).",
     )
     parser.add_argument(
@@ -980,6 +1041,16 @@ def parse_args():
         help="PaddleOCR-VL task mode (default: ocr).",
     )
 
+
+    oneformer_group = parser.add_argument_group("OneFormer options")
+    oneformer_group.add_argument(
+        "--seg_task",
+        type=str,
+        default="panoptic",
+        choices=["semantic", "instance", "panoptic"],
+        help="OneFormer segmentation task (default: panoptic).",
+    )
+
     molmo2_group = parser.add_argument_group("Molmo2 options")
     molmo2_group.add_argument(
         "--task",
@@ -1026,7 +1097,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    image_required_tools = {"pi3", "pi3x", "depth", "segmentation", "detection", "vace", "molmo2", "wilddet3d", "paddleocr_vl", "flowseek"}
+    image_required_tools = {"pi3", "pi3x", "depth", "segmentation", "detection", "vace", "molmo2", "wilddet3d", "paddleocr_vl", "flowseek", "oneformer"}
     if args.tool in image_required_tools and not args.image:
         print(f"Error: --image is required for tool '{args.tool}'")
         sys.exit(1)
@@ -1154,6 +1225,16 @@ def main():
             use_mock=args.use_mock,
             output_dir=args.output_dir,
         )
+    elif args.tool == "oneformer":
+        result_path = test_oneformer(
+            image_paths=args.image,
+            task=args.seg_task,
+            device=args.device,
+            use_mock=args.use_mock,
+            output_dir=args.output_dir,
+            server_url=args.server_url,
+        )
+
 
     # --- summary ---
     print()


### PR DESCRIPTION
## Summary

- Add `OneFormerTool` for universal image segmentation (semantic / instance / panoptic) using a single model
- Implement all three deployment modes: local (in-process), server/client (Flask HTTP, port 20035), and mock
- No manual checkpoint download needed — model auto-downloaded from HuggingFace Hub on first use

## What's Included

**New files:**
- `spagent/external_experts/OneFormer/oneformer_local.py` — HuggingFace Transformers inference, colorized segmentation visualization
- `spagent/external_experts/OneFormer/oneformer_server.py` — Flask server (default port 20035)
- `spagent/external_experts/OneFormer/oneformer_client.py` — HTTP client (base64 encode/decode)
- `spagent/external_experts/OneFormer/__init__.py`
- `spagent/tools/oneformer_tool.py` — tool wrapper with `_MockOneFormerClient`

**Modified files:**
- `spagent/tools/__init__.py` — export `OneFormerTool`
- `examples/evaluation/evaluate_img.py` — add `"oneformer"` config entry
- `test/test_tool.py` — add `test_oneformer()` and CLI dispatch
- `docs/Tool/TOOL_USING.md` — directory tree, overview table, detailed section (§16)
- `readme.md` — Project Structure table, External Experts table, setup section
- `docs/NEW_TOOL_CHECKLIST.md` — add port 20035 to port assignment table

## Setup

No checkpoint download required. Model is auto-downloaded from HuggingFace Hub (~1.5 GB) on first use.

```bash
pip install transformers Pillow

# Optional: use mirror if HuggingFace is slow
export HF_ENDPOINT=https://hf-mirror.com
```

Default model: `shi-labs/oneformer_ade20k_swin_large` (150 ADE20k classes).
Override via env var: `export ONEFORMER_MODEL_ID=shi-labs/oneformer_ade20k_swin_large`

## Usage Examples

**Local mode:**
```python
from spagent.tools import OneFormerTool

tool = OneFormerTool(device="cuda")
result = tool.call(image_path="image.jpg", task="panoptic")   # or semantic / instance
```

**Server mode:**
```bash
python spagent/external_experts/OneFormer/oneformer_server.py --port 20035 --device cuda
```
```python
tool = OneFormerTool(server_url="http://localhost:20035")
result = tool.call(image_path="image.jpg", task="semantic")
```

**Mock mode:**
```python
tool = OneFormerTool(use_mock=True)
result = tool.call(image_path="image.jpg", task="panoptic")
```

## Test Commands

```bash
# Mock mode (no GPU or download needed)
python test/test_tool.py --tool oneformer --image assets/dog.jpeg --use_mock

# Local panoptic (default)
python test/test_tool.py --tool oneformer --image assets/dog.jpeg

# Local semantic
python test/test_tool.py --tool oneformer --image assets/dog.jpeg --task semantic

# Server mode
python test/test_tool.py --tool oneformer --image assets/dog.jpeg \
    --server_url http://localhost:20035
```

---

