### PR TITLE
fix: resolve spagentv05 merge conflicts and repair test_tool.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,9 +39,6 @@ diffusers>=0.31.0
 accelerate>=1.1.1
 ftfy
 einops
-<<<<<<< HEAD
 sentencepiece
-=======
-# VLMEvalKit - install from GitHub: pip install git+https://github.com/open-compass/VLMEvalKit.git
-vlmeval
->>>>>>> spagentv05
+# VLMEvalKit has no PyPI release; install directly from GitHub via PEP 508 direct reference
+vlmeval @ git+https://github.com/open-compass/VLMEvalKit.git

--- a/spagent/tools/__init__.py
+++ b/spagent/tools/__init__.py
@@ -24,11 +24,9 @@ from .wan_tool import WanTool
 from .vace_tool import VaceTool
 from .orient_anything_v2_tool import OrientAnythingV2Tool
 from .sana_tool import SanaTool
-<<<<<<< HEAD
 from .wilddet3d_tool import WildDet3DTool
 from .flowseek_tool import FlowSeekTool
 from .paddleocr_vl_tool import PaddleOCRVLTool
-=======
 from .catalog import (
     TOOL_CATALOG,
     build_all_tools,
@@ -38,7 +36,6 @@ from .catalog import (
     list_catalog_tool_names,
     resolve_tool_keys,
 )
->>>>>>> spagentv05
 
 
 __all__ = [
@@ -63,11 +60,9 @@ __all__ = [
     'VaceTool',
     'OrientAnythingV2Tool',
     'SanaTool',
-<<<<<<< HEAD
     'WildDet3DTool',
     'FlowSeekTool',
     'PaddleOCRVLTool',
-=======
     'TOOL_CATALOG',
     'build_all_tools',
     'build_tools',
@@ -75,5 +70,4 @@ __all__ = [
     'list_catalog_keys',
     'list_catalog_tool_names',
     'resolve_tool_keys',
->>>>>>> spagentv05
 ]

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -773,12 +773,6 @@ def test_flowseek(
     image2_path: str,
     variant: str = "M",
     device: str = "cuda",
-# PaddleOCR-VL-1.5 Tool Test
-# ============================================================
-
-def test_paddleocr_vl(
-    image_paths: List[str],
-    task: str = "ocr",
     server_url: Optional[str] = None,
     use_mock: bool = False,
     output_dir: str = "outputs/tool_test",
@@ -842,6 +836,20 @@ def test_paddleocr_vl(
 
     logger.warning("No output image path in result.")
     return None
+
+
+# ============================================================
+# PaddleOCR-VL-1.5 Tool Test
+# ============================================================
+
+def test_paddleocr_vl(
+    image_paths: List[str],
+    task: str = "ocr",
+    server_url: Optional[str] = None,
+    use_mock: bool = False,
+    output_dir: str = "outputs/tool_test",
+) -> Optional[str]:
+    """
     Directly test PaddleOCR-VL-1.5 document recognition tool.
 
     Args:
@@ -897,14 +905,8 @@ def parse_args():
         "--tool",
         type=str,
         required=True,
-<<<<<<< HEAD
-        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora", "vace", "molmo2", "wilddet3d", "flowseek"],
-        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora", "vace", "molmo2", "wilddet3d", "paddleocr_vl"],
-        help="Which tool to test.",
-=======
-        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora", "vace", "molmo2"],
+        choices=["pi3", "pi3x", "depth", "segmentation", "detection", "veo", "sora", "vace", "molmo2", "wilddet3d", "flowseek", "paddleocr_vl"],
         help="Which tool to test. depth/segmentation/detection now run real inference (no longer stubs).",
->>>>>>> spagentv05
     )
     parser.add_argument(
         "--image",
@@ -1139,6 +1141,11 @@ def main():
             image1_path=args.image[0],
             image2_path=args.image[1],
             device=args.device,
+            server_url=args.server_url,
+            use_mock=args.use_mock,
+            output_dir=args.output_dir,
+        )
+
     elif args.tool == "paddleocr_vl":
         result_path = test_paddleocr_vl(
             image_paths=args.image,


### PR DESCRIPTION
Resolves the unfinished spagentv05<-main merge that left conflict markers committed in three tracked files (broke `import spagent`).

- requirements.txt: keep both `sentencepiece` and VLMEvalKit; install VLMEvalKit via a PEP 508 direct reference (`vlmeval @ git+https://github.com/open-compass/VLMEvalKit.git`) so `pip install -r requirements.txt` pulls it automatically (no PyPI release).
- spagent/tools/__init__.py: keep BOTH sides — the new tool exports (WildDet3DTool/FlowSeekTool/PaddleOCRVLTool) and the catalog API (TOOL_CATALOG/build_tools/resolve_tool_keys/...).
- test/test_tool.py: union the `--tool` choices (adds flowseek + paddleocr_vl) and repair a pre-existing mis-merge (PR #221) that interleaved the test_flowseek and test_paddleocr_vl function bodies and dispatch blocks, which had left the file uncompilable.

Verified: no conflict markers remain; test_tool.py and tools/__init__.py compile; requirements.txt lines are valid PEP 508; `import spagent.tools` succeeds with both new tools and catalog functions exposed.