### PR TITLE
fix(detection): populate top-level boxes/labels from detections

### DIFF
--- a/spagent/tools/detection_tool.py
+++ b/spagent/tools/detection_tool.py
@@ -160,6 +160,30 @@ class _BaseDetectionTool(Tool):
             for i, b in enumerate(boxes)
         ]
 
+    def _surface_boxes(
+        self, raw: Dict[str, Any], detections: List[Dict[str, Any]]
+    ) -> Tuple[List, List, List]:
+        """Return parallel ``(boxes, labels, confidence)`` arrays for the result.
+
+        The real GroundingDINO client returns coordinates only inside
+        ``detections`` (each ``bbox`` is normalized ``cxcywh`` in ``[0, 1]``); it
+        never populates top-level ``boxes``/``labels``/``confidence``. Reading
+        ``raw.get("boxes")`` therefore yielded empty arrays on the real path —
+        only the mock fallback filled them. Derive the arrays from
+        ``detections`` when raw doesn't provide them, so both paths expose the
+        boxes. ``boxes`` mirror ``detections[i]["bbox"]`` (normalized cxcywh).
+        """
+        if raw.get("boxes"):
+            return (
+                raw.get("boxes", []),
+                raw.get("labels", []),
+                raw.get("confidence", []),
+            )
+        boxes = [d.get("bbox") for d in detections]
+        labels = [d.get("label", "obj") for d in detections]
+        confidence = [d.get("confidence") for d in detections if d.get("confidence") is not None]
+        return boxes, labels, confidence
+
     def _bbox_to_pixel_xyxy(self, bbox, img_h: int, img_w: int) -> Tuple[int, int, int, int]:
         """Convert normalized cxcywh → pixel xyxy (or passthrough if already pixel)."""
         a, b, c, d = bbox
@@ -445,13 +469,14 @@ class ZoomObjectTool(_BaseDetectionTool):
                 f"{len(crop_paths)} close-up crop(s) provided for attribute inspection."
             )
             logger.info(msg)
+            boxes, labels, confidence = self._surface_boxes(raw, detections)
             return {
                 "success": True,
                 "result": raw,
                 "detections": detections,
-                "boxes": raw.get("boxes", []),
-                "labels": raw.get("labels", []),
-                "confidence": raw.get("confidence", []),
+                "boxes": boxes,
+                "labels": labels,
+                "confidence": confidence,
                 "output_path": raw.get("output_path"),
                 "vis_path": raw.get("vis_path"),
                 "crop_paths": crop_paths,
@@ -631,13 +656,14 @@ class LocalizeObjectTool(_BaseDetectionTool):
                 f"Annotated full image provided. Positions:\n{text_summary}"
             )
             logger.info(msg)
+            boxes, labels, confidence = self._surface_boxes(raw, detections)
             return {
                 "success": True,
                 "result": raw,
                 "detections": detections,
-                "boxes": raw.get("boxes", []),
-                "labels": raw.get("labels", []),
-                "confidence": raw.get("confidence", []),
+                "boxes": boxes,
+                "labels": labels,
+                "confidence": confidence,
                 "output_path": anno_path,       # annotated full image
                 "vis_path": anno_path,
                 "crop_paths": [],               # no crops for localize mode

--- a/spagent/tools/detection_tool.py
+++ b/spagent/tools/detection_tool.py
@@ -181,7 +181,9 @@ class _BaseDetectionTool(Tool):
             )
         boxes = [d.get("bbox") for d in detections]
         labels = [d.get("label", "obj") for d in detections]
-        confidence = [d.get("confidence") for d in detections if d.get("confidence") is not None]
+        # Keep confidence index-aligned with boxes/labels (None when absent)
+        # so consumers can zip the three arrays safely.
+        confidence = [d.get("confidence") for d in detections]
         return boxes, labels, confidence
 
     def _bbox_to_pixel_xyxy(self, bbox, img_h: int, img_w: int) -> Tuple[int, int, int, int]:


### PR DESCRIPTION
## Problem

On the **real** GroundingDINO path, `zoom_object_tool` / `localize_object_tool`
(and the `detect_objects_tool` alias) returned **empty** top-level `boxes` /
`labels` / `confidence` arrays. The coordinates were only ever present inside
`detections` (each `bbox` is normalized `cxcywh` in `[0,1]`); the top-level
arrays were read from `raw.get("boxes"...)`, which the real client never
populates — only the mock fallback did.

## Fix

Add a shared `_surface_boxes(raw, detections)` helper that derives
`boxes`/`labels`/`confidence` from `detections` when raw doesn't provide them
(preferring raw when present, for mock back-compat), and use it at both `call()`
sites. `boxes` mirror `detections[i]["bbox"]` (normalized cxcywh).

## Real-run verification (real GroundingDINO, single tool, GPU)

`assets/dog.jpeg`, prompt `"dog"`:

| | `detections[0].bbox` | top-level `boxes` | `labels` |
|---|---|---|---|
| **before** | `[0.485,0.459,0.780,0.529]` cxcywh (conf 0.78) | `[]` | `[]` |
| **after** | *same* | `[[0.485,0.459,0.780,0.529]]` | `['dog']` |

`test/test_tool.py --tool detection` (real, `use_mock=False`): **✅ passed**.

## Risk — low / additive

The agent loop reads only `success` / `description` / `output_path` / `vis_path`
/ `crop_paths` — **never** the top-level `boxes`/`labels` (verified in
`spagent/core/spagent.py` and `memory.py`) — so agent behavior is unchanged.
The box data was always available via `detections`; this corrects a latent bug
affecting the detection test and any external consumer of the top-level arrays.
