### PR TITLE
fix(flowseek): stop discarding the raw (u,v) flow field

### DIFF
--- a/spagent/external_experts/FlowSeek/flowseek_local.py
+++ b/spagent/external_experts/FlowSeek/flowseek_local.py
@@ -198,17 +198,27 @@ class FlowSeekLocalClient:
             os.makedirs(Path(output_path).parent, exist_ok=True)
             cv2.imwrite(output_path, flow_vis)
 
+            # Persist the raw dense (H, W, 2) u,v flow field alongside the
+            # visualization. Without this the flow field — the tool's actual
+            # informative output — is discarded, leaving only a scalar mean and
+            # a colorized PNG. Consumers that need per-pixel flow load this .npy.
+            flow_path = str(Path(output_path).with_suffix(".npy"))
+            np.save(flow_path, flow_np.astype(np.float32))
+
             magnitude = float(np.sqrt(flow_np[..., 0] ** 2 + flow_np[..., 1] ** 2).mean())
 
             return {
                 "success": True,
                 "output_path": output_path,
+                "flow_path": flow_path,
+                "flow_shape": list(flow_np.shape),
                 "flow_magnitude_mean": round(magnitude, 4),
                 "description": (
                     f"FlowSeek-{self._variant} estimated optical flow from "
                     f"{Path(image1_path).name} to {Path(image2_path).name}. "
                     f"Mean flow magnitude: {magnitude:.2f} px. "
-                    f"Colorized flow saved to {output_path}."
+                    f"Colorized flow saved to {output_path}; "
+                    f"raw (H,W,2) flow field saved to {flow_path}."
                 ),
             }
 

--- a/spagent/tools/flowseek_tool.py
+++ b/spagent/tools/flowseek_tool.py
@@ -118,17 +118,25 @@ class _MockFlowSeekClient:
     ) -> Dict[str, Any]:
         out = output_path or image1_path
         flow_path = str(Path(out).with_suffix(".npy"))
+        # Write a real (tiny) zero-flow array so flow_path is actually loadable
+        # in mock mode, mirroring the real client's .npy contract.
+        flow_shape = [2, 2, 2]
+        try:
+            import numpy as np
+            np.save(flow_path, np.zeros(flow_shape, dtype=np.float32))
+        except Exception:
+            flow_path = None
         return {
             "success": True,
             "result": {
                 "flow_magnitude_mean": 5.0,
                 "output_path": out,
                 "flow_path": flow_path,
-                "flow_shape": [0, 0, 2],
+                "flow_shape": flow_shape,
             },
             "output_path": out,
             "flow_path": flow_path,
-            "flow_shape": [0, 0, 2],
+            "flow_shape": flow_shape,
             "flow_magnitude_mean": 5.0,
             "description": f"[mock] FlowSeek estimated flow from {Path(image1_path).name} to {Path(image2_path).name}.",
         }

--- a/spagent/tools/flowseek_tool.py
+++ b/spagent/tools/flowseek_tool.py
@@ -99,6 +99,8 @@ class FlowSeekTool(Tool):
                 raw["result"] = {
                     "flow_magnitude_mean": raw.get("flow_magnitude_mean", 0.0),
                     "output_path": raw.get("output_path", ""),
+                    "flow_path": raw.get("flow_path"),
+                    "flow_shape": raw.get("flow_shape"),
                 }
             return raw
         except Exception as e:
@@ -115,13 +117,18 @@ class _MockFlowSeekClient:
         **kwargs,
     ) -> Dict[str, Any]:
         out = output_path or image1_path
+        flow_path = str(Path(out).with_suffix(".npy"))
         return {
             "success": True,
             "result": {
                 "flow_magnitude_mean": 5.0,
                 "output_path": out,
+                "flow_path": flow_path,
+                "flow_shape": [0, 0, 2],
             },
             "output_path": out,
+            "flow_path": flow_path,
+            "flow_shape": [0, 0, 2],
             "flow_magnitude_mean": 5.0,
             "description": f"[mock] FlowSeek estimated flow from {Path(image1_path).name} to {Path(image2_path).name}.",
         }


### PR DESCRIPTION
## Problem

`flowseek` computed the dense `(H, W, 2)` u,v flow field (`flow_np` in the local
client) and then **discarded** it, returning only a scalar `flow_magnitude_mean`
and a colorized PNG. The tool's actual informative output — the per-pixel flow —
never reached any consumer.

## Fix

- Local client: save `flow_np` as a float32 `.npy` next to the visualization and
  return `flow_path` + `flow_shape`.
- Tool wrapper and mock client surface `flow_path`/`flow_shape` too (mock mirrors
  the shape for consistency).

**Scope:** local + mock modes are fully fixed. Server mode still transports only
the PNG (it base64s the image and `os.unlink`s its tempfiles); raw flow over HTTP
is ~16 MB per 1080p frame and needs a served dir / compressed transport —
deferred as a follow-up rather than bundled here.

## Real-run verification (real FlowSeek-M, single tool, GPU)

`frame2` = `frame1` shifted 12 px horizontally:

- returns `flow_path` (`.npy`), `flow_shape` `[1280, 720, 2]`,
  `flow_magnitude_mean` `12.02`
- loaded raw array: **shape `(1280,720,2)` float32, mean dx = 12.019 px**
  (matches the applied shift), mean dy ≈ 0

## Risk — low / additive

The agent loop and the flowseek test consume only the magnitude + PNG, so nothing
existing depended on the raw field; this purely adds the raw payload.
