### PR TITLE
fix(segmentation): guided point/box prompts never reached the real SAM2 client

### DIFF
--- a/spagent/tools/segmentation_tool.py
+++ b/spagent/tools/segmentation_tool.py
@@ -153,22 +153,31 @@ class SegmentationTool(Tool):
                     "error": f"Image file not found: {image_path}"
                 }
             
-            # Prepare arguments for segmentation
-            seg_args = {"image_path": image_path}
-            
+            # Prepare prompt arguments for segmentation
+            prompts = {}
             if point_coords is not None:
-                seg_args["point_coords"] = point_coords
+                prompts["point_coords"] = point_coords
             if point_labels is not None:
-                seg_args["point_labels"] = point_labels
+                prompts["point_labels"] = point_labels
             if box is not None:
-                seg_args["box"] = box
-            
-            # Call segmentation
+                prompts["box"] = box
+
+            # Call segmentation. The real SAM2Client signature is
+            # infer(image_path, prompts=None) with the point/box prompts
+            # nested in a dict; passing them as flat kwargs raised TypeError,
+            # so guided (point/box) segmentation never worked on the real
+            # path. Mock clients keep the flat-kwargs interface.
             if hasattr(self._client, 'infer'):
-                result = self._client.infer(**seg_args)
+                try:
+                    result = self._client.infer(
+                        image_path, prompts=prompts or None
+                    )
+                except TypeError:
+                    # Flat-kwargs client (e.g. inline mock)
+                    result = self._client.infer(image_path=image_path, **prompts)
             else:
                 # Fallback for different client interfaces
-                result = self._client.segment(**seg_args)
+                result = self._client.segment(image_path=image_path, **prompts)
             
             if result and result.get('success'):
                 logger.info("Segmentation completed successfully")


### PR DESCRIPTION
## Problem

`segment_image_tool` passed `point_coords` / `point_labels` / `box` as flat
kwargs, but the real `SAM2Client` signature is `infer(image_path, prompts=None)`
with the prompts nested in a dict — so **every guided (point- or box-prompted)
segmentation raised `TypeError` on the real path**; only automatic mode ever
worked. The bug was invisible to `test/test_tool.py`, which tests automatic
mode only.

## Fix

Wrap the prompts into the dict the client expects, with a flat-kwargs fallback
for the inline mock client.

## Real-run verification (real SAM2.1-b server)

- point-guided (`point_coords=[[360,640]], point_labels=[1]`): **before** → `TypeError: SAM2Client.infer() got an unexpected keyword argument 'point_coords'`; **after** → ✅ success, mask at `outputs/sam_mask_dog.png`
- automatic mode: ✅ unchanged
- mock mode: ✅ unchanged (fallback)
