### PR TITLE
test: add oneformer CALL_KW row (post-#219/#240 merge)

### DIFF
--- a/test/tool_ci_report.py
+++ b/test/tool_ci_report.py
@@ -67,6 +67,7 @@ CALL_KW = {
                          output_path="outputs/vflow.png"),
     "paddleocr_vl": dict(image_path=IMG),
     "wilddet3d":    dict(image_path=IMG, prompt_text="dog"),
+    "oneformer":    dict(image_path=IMG, task="panoptic"),
 }
 
 CHECKS = ["build", "schema", "call", "toolresult", "contract", "render", "boxes", "failpath", "docs"]

--- a/test/verify_all_tools.py
+++ b/test/verify_all_tools.py
@@ -41,6 +41,7 @@ CALL_KW = {
                          output_path="outputs/vflow.png"),
     "paddleocr_vl": dict(image_path=IMG),
     "wilddet3d":    dict(image_path=IMG, prompt_text="dog"),
+    "oneformer":    dict(image_path=IMG, task="panoptic"),
 }
 
 rows = []


### PR DESCRIPTION
Follow-up to #219 + #240: the `oneformer` `CALL_KW` row the author had queued (blocked on #240) was never added because the two PRs merged a day apart. Without it, main's full-catalog lane-1 run fails with `no CALL_KW entry` for oneformer (PR-scoped gating was unaffected).

Adds the row to `test/tool_ci_report.py` and the legacy `test/verify_all_tools.py`. Verified locally: lane 1 full catalog ✅ gate passed; `verify_all_tools.py` 26/26.